### PR TITLE
Add Devin and Cursor CLI installers

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -200,6 +200,22 @@ copilot-cli:
     export APP_BIN="${PROFILE_DIR}/bin"
     ./bin/copilot-cli/install
 
+# Install/upgrade Cursor Agent CLI
+cursor-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PROFILE_DIR="$(pwd)"
+    export APP_BIN="${PROFILE_DIR}/bin"
+    ./bin/cursor-cli/install
+
+# Install/upgrade Devin for Terminal
+devin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PROFILE_DIR="$(pwd)"
+    export APP_BIN="${PROFILE_DIR}/bin"
+    ./bin/devin/install
+
 # Install/upgrade Gemini CLI
 gemini-cli:
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Install everything with `just ai-toolkit`, or pick individual tools:
 | `just claude` | Claude Code |
 | `just cmux` | cmux (Claude multiplexer) |
 | `just copilot` | GitHub Copilot CLI |
+| `just cursor-cli` | Cursor Agent CLI |
+| `just devin` | Devin for Terminal |
 | `just gemini-cli` | Gemini CLI |
 | `just ollama` | Ollama |
 | `just lmstudio` | LM Studio |

--- a/bin/ai-toolkit/install-all
+++ b/bin/ai-toolkit/install-all
@@ -90,6 +90,26 @@ else
 fi
 echo ""
 
+# Cursor Agent CLI
+echo "==> Installing/upgrading Cursor Agent CLI..."
+if "${APP_BIN}/cursor-cli/install"; then
+    echo "✓ Cursor Agent CLI completed successfully"
+else
+    echo "✗ Cursor Agent CLI failed"
+    failed_installs+=("cursor-cli")
+fi
+echo ""
+
+# Devin for Terminal
+echo "==> Installing/upgrading Devin for Terminal..."
+if "${APP_BIN}/devin/install"; then
+    echo "✓ Devin for Terminal completed successfully"
+else
+    echo "✗ Devin for Terminal failed"
+    failed_installs+=("devin")
+fi
+echo ""
+
 # Gemini CLI
 echo "==> Installing/upgrading Gemini CLI..."
 if "${APP_BIN}/gemini-cli/install"; then

--- a/bin/cursor-cli/install
+++ b/bin/cursor-cli/install
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+set -euo pipefail
+
+shopt -s failglob
+
+usage() {
+    cat <<'EOF'
+Usage: bin/cursor-cli/install [--help]
+
+Install or upgrade the official Cursor Agent CLI.
+
+macOS/Linux: uses the official installer at https://cursor.com/install.
+
+Note: the Homebrew cask has shipped builds that are missing native .node files
+(e.g. merkle-tree-napi.darwin-arm64.node). This wrapper intentionally prefers
+Cursor's official ~/.local/share installer and removes the cask when present so
+/opt/homebrew/bin does not shadow the working local binary.
+
+Installed commands:
+  cursor-agent  Official binary name
+  agent         Convenience alias used by Cursor docs when safe to create
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+# Set PROFILE_DIR and APP_BIN if not already set
+if [ -z "${PROFILE_DIR:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export PROFILE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+
+if [ -z "${APP_BIN:-}" ]; then
+    export APP_BIN="${PROFILE_DIR}/bin"
+fi
+
+. "${APP_BIN}/sh/shell_fns" --source-only
+. "${APP_BIN}/sh/brew_helper.sh"
+
+app_name="cursor-cli"
+
+MACHINE="$(uname -s)"
+INSTALL_URL="https://cursor.com/install"
+
+ensure_download_prereqs() {
+    local missing=()
+    for cmd in curl tar; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            missing+=("${cmd}")
+        fi
+    done
+
+    if [ ${#missing[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    echo "Installing prerequisites: ${missing[*]}"
+    case "${MACHINE}" in
+        Darwin)
+            ensure_brew_in_path || {
+                echo "ERROR: Homebrew not found. Please install Homebrew first."
+                exit 1
+            }
+            for cmd in "${missing[@]}"; do
+                brew install "${cmd}"
+            done
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null 2>&1; then
+                sudo apt-get update
+                sudo apt-get install -y "${missing[@]}"
+            elif command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y "${missing[@]}"
+            elif command -v yum >/dev/null 2>&1; then
+                sudo yum install -y "${missing[@]}"
+            else
+                echo "ERROR: Could not install prerequisites (${missing[*]}). Please install them manually."
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unsupported platform: ${MACHINE}"
+            exit 1
+            ;;
+    esac
+}
+
+ensure_agent_alias() {
+    if [ ! -x "$HOME/.local/bin/cursor-agent" ]; then
+        return 0
+    fi
+
+    mkdir -p "$HOME/.local/bin"
+    ln -sfn "$HOME/.local/bin/cursor-agent" "$HOME/.local/bin/agent"
+    echo "✓ Linked ~/.local/bin/agent -> ~/.local/bin/cursor-agent"
+}
+
+remove_shadowing_homebrew_cask() {
+    if ! command -v brew >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! brew list --cask cursor-cli >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "Removing Homebrew cursor-cli cask to avoid shadowing the official install..."
+    brew uninstall --cask cursor-cli || {
+        echo "WARNING: failed to uninstall Homebrew cursor-cli cask."
+        echo "If cursor-agent still resolves to /opt/homebrew/bin/cursor-agent, run: brew uninstall --cask cursor-cli"
+    }
+}
+
+validate_cursor_agent() {
+    local candidate="$HOME/.local/bin/cursor-agent"
+    if [ ! -x "${candidate}" ]; then
+        echo "ERROR: ${candidate} was not installed."
+        exit 1
+    fi
+
+    if ! "${candidate}" --help >/dev/null 2>&1; then
+        echo "ERROR: Cursor Agent CLI installed but failed smoke validation."
+        echo "Try reinstalling with: curl -fsSL ${INSTALL_URL} | bash"
+        exit 1
+    fi
+}
+
+install_messages "start" "$app_name"
+ensure_download_prereqs
+
+case "${MACHINE}" in
+    Darwin|Linux)
+        if [ -x "$HOME/.local/bin/cursor-agent" ]; then
+            echo "Cursor Agent CLI already installed at $HOME/.local/bin/cursor-agent. Running official installer to check for updates..."
+        else
+            echo "Installing Cursor Agent CLI with official installer..."
+        fi
+        curl -fsSL "${INSTALL_URL}" | bash
+        ensure_agent_alias
+        remove_shadowing_homebrew_cask
+        validate_cursor_agent
+        ;;
+    *)
+        echo "Unsupported platform: ${MACHINE}"
+        exit 1
+        ;;
+esac
+
+install_messages "end" "$app_name"
+
+echo ""
+echo "Cursor Agent CLI installed successfully!"
+echo "Binary: $(command -v cursor-agent)"
+echo "Version: $(cursor-agent --version 2>/dev/null || echo 'version command unavailable')"
+echo "Usage:"
+echo "  cursor-agent --help"
+echo "  agent"
+echo ""

--- a/bin/devin/install
+++ b/bin/devin/install
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+shopt -s failglob
+
+usage() {
+    cat <<'EOF'
+Usage: bin/devin/install [--help]
+
+Install or upgrade Devin for Terminal.
+
+Official installer: https://cli.devin.ai/install.sh
+Installs the `devin` binary into ~/.local/bin and may run Devin's local setup flow.
+No API keys or credentials are read or printed by this wrapper.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+# Set PROFILE_DIR and APP_BIN if not already set
+if [ -z "${PROFILE_DIR:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export PROFILE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+
+if [ -z "${APP_BIN:-}" ]; then
+    export APP_BIN="${PROFILE_DIR}/bin"
+fi
+
+. "${APP_BIN}/sh/shell_fns" --source-only
+. "${APP_BIN}/sh/brew_helper.sh"
+
+app_name="devin"
+
+MACHINE="$(uname -s)"
+INSTALL_URL="https://cli.devin.ai/install.sh"
+
+ensure_download_prereqs() {
+    local missing=()
+    for cmd in curl tar; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            missing+=("${cmd}")
+        fi
+    done
+
+    if [ ${#missing[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    echo "Installing prerequisites: ${missing[*]}"
+    case "${MACHINE}" in
+        Darwin)
+            ensure_brew_in_path || {
+                echo "ERROR: Homebrew not found. Please install Homebrew first."
+                exit 1
+            }
+            for cmd in "${missing[@]}"; do
+                brew install "${cmd}"
+            done
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null 2>&1; then
+                sudo apt-get update
+                sudo apt-get install -y "${missing[@]}"
+            elif command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y "${missing[@]}"
+            elif command -v yum >/dev/null 2>&1; then
+                sudo yum install -y "${missing[@]}"
+            else
+                echo "ERROR: Could not install prerequisites (${missing[*]}). Please install them manually."
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unsupported platform: ${MACHINE}"
+            exit 1
+            ;;
+    esac
+}
+
+install_messages "start" "$app_name"
+ensure_download_prereqs
+
+if command -v devin >/dev/null 2>&1; then
+    echo "Devin for Terminal already installed at $(command -v devin). Checking for updates..."
+else
+    echo "Installing Devin for Terminal..."
+fi
+
+echo "Running official Devin installer: ${INSTALL_URL}"
+set +e
+curl -fsSL "${INSTALL_URL}" | bash
+installer_status=$?
+set -e
+
+if ! command -v devin >/dev/null 2>&1; then
+    echo "ERROR: devin was not found in PATH after installation. Ensure ~/.local/bin is in PATH."
+    exit 1
+fi
+
+if [ "${installer_status}" -ne 0 ]; then
+    echo "WARNING: Devin installer exited with status ${installer_status} after installing the binary."
+    echo "This commonly happens when the post-install login/setup flow is canceled or non-interactive."
+    echo "Run 'devin setup' or just start 'devin' in an interactive terminal to finish authentication."
+fi
+
+install_messages "end" "$app_name"
+
+echo ""
+echo "Devin for Terminal installed successfully!"
+echo "Binary: $(command -v devin)"
+echo "Version: $(devin --version 2>/dev/null || echo 'version command unavailable')"
+echo "Usage:"
+echo "  devin --help"
+echo "  devin -- <prompt>"
+echo ""


### PR DESCRIPTION
## Summary
- Add reproducible installers for Devin for Terminal and Cursor Agent CLI
- Add just recipes: `just devin` and `just cursor-cli`
- Include both tools in `just ai-toolkit` and README
- Prefer Cursor's official installer over the Homebrew cask because the cask install can miss native .node bindings such as `merkle-tree-napi.darwin-arm64.node`

## Validation
- `just --dry-run devin`
- `just --dry-run cursor-cli`
- `just --dry-run ai-toolkit`
- `bash -n bin/devin/install bin/cursor-cli/install bin/ai-toolkit/install-all`
- Installed locally and verified:
  - `devin --version` → `devin 2026.5.1-1 (a613a09)`
  - `cursor-agent --version` → `2026.04.30-4edb302`
  - `agent --version` → `2026.04.30-4edb302`