### PR TITLE
Add secure Cursor bootstrap and agent registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Codex / Cursor Instructions — profile
+
+Tool-only repo. No Cartesia project context, customer data, or work notes.
+
+## Cursor Agent CLI
+
+| Item | Path |
+|------|------|
+| Installer | `bin/cursor-cli/install` |
+| Secure bootstrap | `bin/cursor-cli/setup` |
+| User config | `~/.cursor/cli-config.json` |
+| Project overrides | `<repo>/.cursor/cli.json` (merged at session start) |
+
+### Bootstrap
+
+```bash
+just cursor-cli    # install/upgrade cursor-agent
+just cursor-setup  # link agents/skills + validate models
+```
+
+### Model defaults (orchestrator samples)
+
+| Role | Cursor model slug | Analog |
+|------|-------------------|--------|
+| Complex orchestration | `claude-opus-4-8-thinking-high` | Codex orchestrator / fleet designer |
+| Implementation / validation | `gpt-5.5-high` | Codex gpt-5.5 workers |
+
+Override per session: `cursor-agent --model <slug>`.
+
+### Security defaults (enforced by setup + project cli.json)
+
+- `approvalMode`: `allowlist` — never `--force` / `--yolo` for fleet work
+- `sandbox.mode`: `disabled` on dev Macs; use cdev/cagent sandboxes for risky remote work
+- Secrets: never commit; fleet secrets at `~/.local/share/fleet/` only
+- No Cartesia proprietary paths in committed profile artifacts
+
+### Fleet registry
+
+`bin/nvim/lua/kh/agent_registry.lua` is the shared agent-type source for tmux/fleet UIs. Cursor is registered there when present.

--- a/Justfile
+++ b/Justfile
@@ -208,6 +208,15 @@ cursor-cli:
     export APP_BIN="${PROFILE_DIR}/bin"
     ./bin/cursor-cli/install
 
+# Bootstrap secure Cursor agents/skills + cli-config defaults
+cursor-setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PROFILE_DIR="$(pwd)"
+    export APP_BIN="${PROFILE_DIR}/bin"
+    chmod +x ./bin/cursor-cli/setup
+    ./bin/cursor-cli/setup
+
 # Install/upgrade Devin for Terminal
 devin:
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install everything with `just ai-toolkit`, or pick individual tools:
 | `just cmux` | cmux (Claude multiplexer) |
 | `just copilot` | GitHub Copilot CLI |
 | `just cursor-cli` | Cursor Agent CLI |
+| `just cursor-setup` | Secure Cursor bootstrap (agents, skills, cli-config) |
 | `just devin` | Devin for Terminal |
 | `just gemini-cli` | Gemini CLI |
 | `just ollama` | Ollama |

--- a/bin/cursor-cli/setup
+++ b/bin/cursor-cli/setup
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Secure Cursor bootstrap: install CLI, link agents/skills, validate models.
+set -euo pipefail
+shopt -s failglob
+
+usage() {
+    cat <<'EOF'
+Usage: bin/cursor-cli/setup [--help] [--work-repo PATH] [--orchestrator-model SLUG] [--worker-model SLUG]
+
+Install Cursor Agent CLI (if needed), link secure agents/skills into ~/.cursor,
+and smoke-test model availability.
+
+Defaults:
+  work repo   ~/src/karan.hiremath
+  orchestrator claude-opus-4-8-thinking-high
+  worker       gpt-5.5-high
+
+Does not print secrets. Does not enable --force / Run Everything.
+EOF
+}
+
+WORK_REPO="${KARAN_HIREMATH_REPO:-$HOME/src/karan.hiremath}"
+ORCH_MODEL="${CURSOR_ORCHESTRATOR_MODEL:-claude-opus-4-8-thinking-high}"
+WORKER_MODEL="${CURSOR_WORKER_MODEL:-gpt-5.5-high}"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --work-repo) WORK_REPO="$2"; shift 2 ;;
+        --orchestrator-model) ORCH_MODEL="$2"; shift 2 ;;
+        --worker-model) WORKER_MODEL="$2"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "${PROFILE_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export PROFILE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+export APP_BIN="${PROFILE_DIR}/bin"
+
+"${APP_BIN}/cursor-cli/install"
+
+mkdir -p "$HOME/.cursor/agents" "$HOME/.cursor/skills"
+
+link_agent() {
+    local name="$1"
+    local src="$WORK_REPO/.cursor/agents/${name}.md"
+    local dst="$HOME/.cursor/agents/${name}.md"
+    if [[ ! -f "$src" ]]; then
+        echo "WARNING: missing agent source $src (clone karan.hiremath first)" >&2
+        return 0
+    fi
+    ln -sfn "$src" "$dst"
+    echo "✓ agent $name"
+}
+
+for agent in fleet-designer cartesia-security-context bifrost-context gypsum-context training-cluster-setup-context; do
+    link_agent "$agent"
+done
+
+if [[ -d "$HOME/.claude/skills" ]]; then
+    for skill_dir in "$HOME/.claude/skills"/*; do
+        [[ -d "$skill_dir" && -f "$skill_dir/SKILL.md" ]] || continue
+        name="$(basename "$skill_dir")"
+        ln -sfn "$skill_dir" "$HOME/.cursor/skills/$name"
+        echo "✓ skill $name"
+    done
+fi
+
+if [[ -d "$WORK_REPO/agentic/skills" ]]; then
+    for skill_dir in "$WORK_REPO/agentic/skills"/*; do
+        [[ -d "$skill_dir" && -f "$skill_dir/SKILL.md" ]] || continue
+        name="$(basename "$skill_dir")"
+        ln -sfn "$skill_dir" "$HOME/.cursor/skills/kh-$name"
+        echo "✓ skill kh-$name"
+    done
+fi
+
+python3 - <<'PY' "$HOME/.cursor/cli-config.json" "$ORCH_MODEL" "$WORKER_MODEL"
+import json, pathlib, sys
+path, orch, worker = sys.argv[1:4]
+p = pathlib.Path(path)
+data = json.loads(p.read_text()) if p.exists() else {"version": 1}
+data.setdefault("permissions", {})
+allow = data["permissions"].setdefault("allow", [])
+deny = data["permissions"].setdefault("deny", [])
+for entry in [
+    "Shell(git status)", "Shell(git diff*)", "Shell(git log*)", "Shell(git branch*)",
+    "Shell(git fetch*)", "Shell(git show*)", "Shell(git rev-parse*)",
+    "Shell(gh pr list*)", "Shell(gh pr view*)", "Shell(gh issue list*)",
+    "Shell(gh api*)", "Shell(ls)", "Shell(pwd)", "Shell(which*)",
+    "Shell(uv run pytest*)", "Shell(just *)", "Shell(cauth *)", "Shell(caudit *)",
+    "Shell(cscan *)", "Shell(cpatch *)", "Shell(cdev *)",
+]:
+    if entry not in allow:
+        allow.append(entry)
+for entry in [
+    "Shell(git push --force*)", "Shell(git push -f*)",
+    "Shell(terraform apply*)", "Shell(terraform destroy*)",
+]:
+    if entry not in deny:
+        deny.append(entry)
+data["approvalMode"] = data.get("approvalMode", "allowlist")
+data.setdefault("sandbox", {})["mode"] = data.get("sandbox", {}).get("mode", "disabled")
+data.setdefault("attribution", {})["attributeCommitsToAgent"] = True
+data.setdefault("attribution", {})["attributePRsToAgent"] = True
+data["cursorSetup"] = {"orchestratorModel": orch, "workerModel": worker}
+p.write_text(json.dumps(data, indent=2) + "\n")
+print(f"✓ cli-config.json updated (orchestrator={orch}, worker={worker})")
+PY
+
+if command -v cursor-agent >/dev/null 2>&1; then
+    cursor-agent --list-models 2>/dev/null | rg -q "$ORCH_MODEL" && echo "✓ orchestrator model available: $ORCH_MODEL" \
+        || echo "WARNING: orchestrator model not listed: $ORCH_MODEL" >&2
+    cursor-agent --list-models 2>/dev/null | rg -q "$WORKER_MODEL" && echo "✓ worker model available: $WORKER_MODEL" \
+        || echo "WARNING: worker model not listed: $WORKER_MODEL" >&2
+fi
+
+echo ""
+echo "Cursor secure setup complete."
+echo "  Orchestrator: cursor-agent --model $ORCH_MODEL"
+echo "  Worker:       cursor-agent --model $WORKER_MODEL"
+echo "  Work repo:    $WORK_REPO"

--- a/bin/nvim/lua/kh/agent_registry.lua
+++ b/bin/nvim/lua/kh/agent_registry.lua
@@ -1,0 +1,173 @@
+--- agent_registry.lua: Shared agent type definitions for fleet management.
+local M = {}
+
+M.VERSION = "1.1.0"
+
+M.agents = {
+  pi = {
+    type  = "pi",
+    label = "Pi Coding Agent",
+    icon  = "π",
+    color = "magenta",
+    detect = { cmds = { "node" }, title_pats = { "^π", "^✳", "^pi:" }, path_hints = { "pi" } },
+    spawn = { cmd = "pi", default_args = {}, continue_flag = "-c", project_flag = nil },
+    session = { dir = "~/.pi/agent/sessions", file_pattern = "*.jsonl" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Working", "Running", "Executing" },
+      waiting_pats = { "%$%d+%.%d+", "↑%d", "↓%d" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = false, session_file = true },
+  },
+
+  cursor = {
+    type  = "cursor",
+    label = "Cursor Agent",
+    icon  = "◆",
+    color = "cyan",
+    detect = {
+      cmds       = { "cursor-agent", "agent" },
+      title_pats = { "cursor", "Cursor", "Composer" },
+      path_hints = { "cursor-agent", "agent" },
+    },
+    spawn = {
+      cmd           = "cursor-agent",
+      default_args  = { "--model", "claude-opus-4-8-thinking-high" },
+      continue_flag = "--continue",
+      project_flag  = "--workspace",
+    },
+    session = {
+      dir          = "~/.cursor/projects",
+      file_pattern = "**/agent-transcripts/**/*.jsonl",
+    },
+    status = {
+      strategy     = "tui_capture",
+      working_pats = { "Thinking", "Running", "Executing", "Working" },
+      waiting_pats = { "^>", "❯" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+
+  claude = {
+    type  = "claude",
+    label = "Claude Code",
+    icon  = "C",
+    color = "cyan",
+    detect = { cmds = { "claude" }, title_pats = { "claude", "Claude" }, path_hints = { "claude" } },
+    spawn = { cmd = "claude", default_args = {}, continue_flag = "--continue", project_flag = nil },
+    session = { dir = "~/.claude/projects", file_pattern = "*.json" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Thinking", "Reading", "Editing", "Running", "Searching", "Writing", "Creating" },
+      waiting_pats = { "^>", "^❯", "What would you like" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+
+  codex = {
+    type  = "codex",
+    label = "Codex CLI",
+    icon  = "X",
+    color = "green",
+    detect = { cmds = { "codex" }, title_pats = { "codex", "Codex" }, path_hints = { "codex" } },
+    spawn = { cmd = "codex", default_args = {}, continue_flag = "", project_flag = nil },
+    session = { dir = "~/.codex", file_pattern = "*.json" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Thinking", "Running", "Executing" },
+      waiting_pats = { "^>", "❯" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+}
+
+M.order = { "pi", "cursor", "claude", "codex" }
+
+function M.get(agent_type) return M.agents[agent_type] end
+
+function M.all()
+  local result = {}
+  for _, key in ipairs(M.order) do
+    if M.agents[key] then result[#result + 1] = M.agents[key] end
+  end
+  return result
+end
+
+function M.available()
+  local result = {}
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    if agent then
+      for _, hint in ipairs(agent.detect.path_hints) do
+        if vim.fn.exepath(hint) ~= "" then
+          result[#result + 1] = agent
+          break
+        end
+      end
+    end
+  end
+  return result
+end
+
+function M.match_pane(cmd, title)
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    local cmd_match = false
+    for _, c in ipairs(agent.detect.cmds) do
+      if cmd == c then cmd_match = true; break end
+    end
+    if cmd_match then
+      if #agent.detect.title_pats > 0 then
+        for _, pat in ipairs(agent.detect.title_pats) do
+          if title:match(pat) then return agent end
+        end
+      else
+        return agent
+      end
+    end
+  end
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    for _, pat in ipairs(agent.detect.title_pats) do
+      if title:match(pat) then return agent end
+    end
+  end
+  return nil
+end
+
+function M.expand_path(path)
+  if not path then return nil end
+  return vim.fn.expand(path)
+end
+
+function M.spawn_cmd(agent_type, dir, extra_args)
+  local agent = M.agents[agent_type]
+  if not agent then return nil end
+  local bin = vim.fn.exepath(agent.spawn.cmd)
+  if bin == "" then bin = agent.spawn.cmd end
+  local parts = { bin }
+  for _, arg in ipairs(agent.spawn.default_args) do parts[#parts + 1] = arg end
+  if extra_args then
+    for _, arg in ipairs(extra_args) do parts[#parts + 1] = arg end
+  end
+  local cmd = table.concat(parts, " ")
+  if dir then cmd = "cd " .. vim.fn.shellescape(dir) .. " && " .. cmd end
+  return cmd
+end
+
+M.status_icons = { waiting = "⏳", working = "⚙️ ", init = "✳ ", idle = "💤", unknown = "❓" }
+
+function M.to_json()
+  return vim.fn.json_encode({ version = M.VERSION, agents = M.agents, order = M.order })
+end
+
+function M.export(path)
+  path = path or vim.fn.expand("~/.config/fleet/agent-registry.json")
+  local dir = vim.fn.fnamemodify(path, ":h")
+  vim.fn.mkdir(dir, "p")
+  local f = io.open(path, "w")
+  if f then f:write(M.to_json()); f:close(); return true end
+  return false
+end
+
+return M


### PR DESCRIPTION
## Summary
- Add `just cursor-setup` / `bin/cursor-cli/setup` to install Cursor CLI, link karan.hiremath subagents/skills into `~/.cursor/`, and apply allowlist defaults.
- Register Cursor in `bin/nvim/lua/kh/agent_registry.lua` for fleet/tmux detection.
- Document model routing: Opus 4.8 orchestrator, GPT 5.5 worker.

## Test plan
- [ ] `just cursor-setup` on a machine with `~/src/karan.hiremath` checked out
- [ ] Verify `~/.cursor/agents/fleet-designer.md` symlink resolves
- [ ] `cursor-agent --list-models | rg 'opus-4-8|gpt-5.5'`
- [ ] Confirm `~/.cursor/cli-config.json` has allowlist + deny force-push/terraform apply


Made with [Cursor](https://cursor.com)