### PR TITLE
Make tmux extended keys config optional

### DIFF
--- a/bin/tmux/tmux.conf
+++ b/bin/tmux/tmux.conf
@@ -15,8 +15,10 @@ set -g status-right '#{prefix_highlight} %a %Y-%m-%d %H:%M:%S | %s '
 set -g status-left-length 32
 set -g status-interval 1
 
-set -g extended-keys on
-set -g extended-keys-format csi-u
+# Ubuntu 22.04 ships tmux 3.2a and some hosts run tmux 3.4; both lack
+# extended-keys-format. Use -q so unsupported options do not abort config load.
+set -gq extended-keys on
+set -gq extended-keys-format csi-u
 
 bind-key m set-option -g mouse on \; display 'Mouse: ON'
 bind-key M set-option -g mouse off \; display 'Mouse: OFF'


### PR DESCRIPTION
## Summary\n- use tmux `set -gq` for extended keys options so Ubuntu 22.04 tmux 3.2a / tmux 3.4 hosts do not abort config loading\n\n## Validation\n- loaded config with local tmux via `tmux -f bin/tmux/tmux.conf start-server \; source-file bin/tmux/tmux.conf`