### PR TITLE
Hermes voice-agent launcher + Cartesia TTS/STT plugin for terminal/tmux/TUI use

### DIFF
--- a/bin/hermes/README.md
+++ b/bin/hermes/README.md
@@ -1,0 +1,88 @@
+# Hermes tooling manager
+
+Generic profile-level tooling for installing Hermes CLI packages and syncing a personal private Hermes workflow repo.
+
+Data boundary:
+- OK: generic install scripts, generic wrappers, personal non-work workflow scaffolds.
+- Not OK: Cartesia-specific prompts, hosts, customer names, security findings, credentials, or internal runbooks.
+- Work Hermes setup belongs in the Cartesia work repo.
+
+## Commands
+
+```bash
+bin/hermes/install       # isolated tool install under ~/.local/share/hermes-toolchain
+bin/hermes/install-tui   # isolated Bun runtime for herm TUI
+bin/hermes/configure-machine # machine-aware model/auth/config setup
+bin/hermes/private-sync  # clone/update private personal repo
+bin/hermes/doctor        # non-secret status
+bin/hermes/env           # print PATH additions
+bin/hermes/agents        # run isolated Hermes voice agents for daily terminal use
+```
+
+## Voice agents (`agents`)
+
+Run isolated Hermes voice agents (each in its own `HERMES_HOME`) wired to the
+Cartesia TTS/STT plugin (`plugins/cartesia/`) for day-to-day terminal / tmux /
+TUI (and messaging) workflows. Each profile picks an endpoint and voice; bring
+one up as a CLI, TUI, or messaging gateway.
+
+```bash
+bin/hermes/agents list                 # profiles, surface, endpoint, home status
+bin/hermes/agents resolve staging-voice # show resolved config (internal host redacted)
+bin/hermes/agents check staging-voice   # materialize + end-to-end endpoint health check
+bin/hermes/agents up staging-voice                      # launch (profile's default surface)
+bin/hermes/agents up staging-voice --surface tui
+bin/hermes/agents up staging-voice --surface gateway --platform telegram --check
+bin/hermes/agents new my-voice          # scaffold profiles/my-voice.yaml from TEMPLATE
+```
+
+- Profiles are loaded from a search **path** (first match wins), so each profile
+  lives where it belongs:
+  - `work` → `~/src/karan.hiremath/agentic/hermes/profiles/` (internal Cartesia validation)
+  - `personal` → `~/src/hermes/profiles/` (public/personal)
+  - `profile` → `bin/hermes/profiles/` (this repo — generic `TEMPLATE` only)
+  Override the whole path with `HERMES_AGENT_PROFILE_PATH` (os.pathsep-separated).
+  Create into a specific repo: `agents new <name> --dir work|personal|profile|<path>`.
+- Isolated homes live under `${XDG_DATA_HOME:-~/.local/share}/hermes-validation/<profile>/`.
+- Secrets: `CARTESIA_API_KEY` (+ internal endpoint hosts like
+  `CARTESIA_STAGING_URL`) live in machine-local `~/.hermes/.env`, never here.
+  Homes derive their `.env` from it; gateway platform tokens set per-home survive.
+
+Defaults:
+- toolchain: `${XDG_DATA_HOME:-$HOME/.local/share}/hermes-toolchain`
+- npm prefix: `<toolchain>/npm`
+- Python venv: `<toolchain>/venv`
+- Bun runtime: `<toolchain>/bun`
+- private repo: `git@github.com:karanhiremath/hermes.git`
+- private checkout: `$HOME/src/hermes`
+
+The installer uses `uv venv` and prepends the venv to `PATH` while running npm so package lifecycle Python installs land in the Hermes toolchain venv, not system Python.
+
+The TUI installer downloads the Bun release asset for the current OS/arch, verifies it against `SHASUMS256.txt`, and installs it under the Hermes toolchain instead of using the global Bun installer.
+
+`install` writes user-local shims to `${HERMES_SHIM_DIR:-$HOME/.local/bin}` for `hermes`, `hermes-agent`, and `herm`. If that directory is already on PATH, no `source <(.../env)` step is needed.
+
+## Machine-aware setup
+
+`configure-machine` reads a non-secret profile from:
+
+```text
+${HERMES_PRIVATE_DIR:-$HOME/src/hermes}/machines/${HERMES_MACHINE_PROFILE:-$(hostname -s)}/hermes.yaml
+```
+
+Example profile:
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+auth:
+  import_codex_cli: true
+```
+
+Ansible entrypoint:
+
+```bash
+ansible-playbook -i <inventory> <profile_repo>/bin/hermes/ansible/hermes.yml
+```

--- a/bin/hermes/agents
+++ b/bin/hermes/agents
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Spin up isolated Hermes voice agents from declarative profiles, for day-to-day
+# terminal / tmux / TUI (and messaging) use.
+# Usage: agents <command> [args]
+#
+#   list                       List profiles (merged across the profile path)
+#   resolve <profile>          Show the resolved config for a profile (host redacted)
+#   new <name> [--dir D]       Scaffold a profile from TEMPLATE.
+#                              D = work | personal | profile | <path> (default: personal)
+#   check <profile>            Materialize + run an end-to-end endpoint health check
+#   up <profile> [opts] [-- ...args]
+#                              Materialize the isolated home and launch the agent
+#       --surface cli|tui|gateway   Override the profile's default surface
+#       --platform <name>           Messaging platform for surface=gateway
+#       --check                     Run an endpoint health check before launching
+#       -- <args>                   Pass remaining args through to hermes/herm
+#
+# Each agent runs under its own HERMES_HOME so it never touches ~/.hermes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY_BACKEND="$SCRIPT_DIR/hermes_agents.py"
+TEMPLATE_SRC="$SCRIPT_DIR/profiles/TEMPLATE.yaml"
+PLUGIN_DIR="$SCRIPT_DIR/plugins/cartesia"
+
+# Resolve a `new --dir` target: keyword shorthand or a literal path.
+resolve_profile_dir() {
+  case "$1" in
+    work)     echo "$HOME/src/karan.hiremath/agentic/hermes/profiles" ;;
+    personal) echo "$HOME/src/hermes/profiles" ;;
+    profile)  echo "$SCRIPT_DIR/profiles" ;;
+    *)        echo "$1" ;;
+  esac
+}
+
+HERMES_TOOLCHAIN_HOME="${HERMES_TOOLCHAIN_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}/hermes-toolchain}"
+VENV="${HERMES_PYTHON_VENV:-$HERMES_TOOLCHAIN_HOME/venv}"
+PY="$VENV/bin/python"
+SHIM_DIR="${HERMES_SHIM_DIR:-$HOME/.local/bin}"
+export PATH="$SHIM_DIR:$VENV/bin:$PATH"
+
+usage() { sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; }
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -x "$PY" ] || die "Hermes venv python missing ($PY); run bin/hermes/install first"
+
+materialize() {
+  "$PY" "$PY_BACKEND" materialize "$1"
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  -h|--help|help|"") usage; exit 0 ;;
+
+  list)
+    "$PY" "$PY_BACKEND" list
+    ;;
+
+  resolve)
+    [ "$#" -ge 1 ] || die "resolve needs a profile name"
+    "$PY" "$PY_BACKEND" resolve "$1"
+    ;;
+
+  new)
+    [ "$#" -ge 1 ] || die "new needs a name"
+    name="$1"; shift
+    target="personal"
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --dir) target="${2:?}"; shift 2 ;;
+        *) die "unknown option: $1" ;;
+      esac
+    done
+    dir="$(resolve_profile_dir "$target")"
+    mkdir -p "$dir"
+    dst="$dir/$name.yaml"
+    [ -e "$dst" ] && die "profile already exists: $dst"
+    sed "s/^name: TEMPLATE/name: $name/" "$TEMPLATE_SRC" > "$dst"
+    echo "created $dst ($(resolve_profile_dir "$target" >/dev/null && echo "$target"))"
+    echo "edit it, then: agents check $name"
+    ;;
+
+  check)
+    [ "$#" -ge 1 ] || die "check needs a profile name"
+    home="$(materialize "$1")"
+    echo "home=$home"
+    HERMES_HOME="$home" "$PY" "$PLUGIN_DIR/validate.py" --tts --stt
+    ;;
+
+  up)
+    [ "$#" -ge 1 ] || die "up needs a profile name"
+    profile="$1"; shift
+    surface=""; platform=""; do_check=0; passthrough=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --surface) surface="${2:?}"; shift 2 ;;
+        --platform) platform="${2:?}"; shift 2 ;;
+        --check) do_check=1; shift ;;
+        --) shift; passthrough=("$@"); break ;;
+        *) die "unknown option: $1" ;;
+      esac
+    done
+
+    # Default surface from the profile if not overridden.
+    [ -n "$surface" ] || surface="$("$PY" "$PY_BACKEND" resolve "$profile" | sed -n 's/.*"surface": *"\([^"]*\)".*/\1/p')"
+    [ -n "$surface" ] || surface="cli"
+
+    home="$(materialize "$profile")"
+    echo "profile=$profile surface=$surface home=$home"
+
+    if [ "$do_check" -eq 1 ]; then
+      HERMES_HOME="$home" "$PY" "$PLUGIN_DIR/validate.py" --tts --stt || die "endpoint health check failed; not launching"
+    fi
+
+    export HERMES_HOME="$home"
+    case "$surface" in
+      cli)
+        command -v hermes >/dev/null 2>&1 || die "hermes not on PATH"
+        exec hermes chat "${passthrough[@]}"
+        ;;
+      tui)
+        command -v herm >/dev/null 2>&1 || die "herm (TUI) not installed; run bin/hermes/install-tui"
+        exec herm "${passthrough[@]}"
+        ;;
+      gateway)
+        command -v hermes >/dev/null 2>&1 || die "hermes not on PATH"
+        [ -n "$platform" ] && export HERMES_GATEWAY_PLATFORM="$platform"
+        echo "Launching gateway (platform: ${platform:-from config}). Configure tokens in $home/.env"
+        echo "First time? run:  HERMES_HOME=$home hermes gateway setup"
+        exec hermes gateway run "${passthrough[@]}"
+        ;;
+      *) die "unknown surface: $surface (use cli|tui|gateway)" ;;
+    esac
+    ;;
+
+  *) die "unknown command: $cmd (try: agents help)" ;;
+esac

--- a/bin/hermes/hermes_agents.py
+++ b/bin/hermes/hermes_agents.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Backend for the `agents` launcher: resolve an agent profile and materialize
+an isolated HERMES_HOME for it.
+
+Each agent gets its own HERMES_HOME under
+``$XDG_DATA_HOME/hermes-agents/<name>/`` so it never touches the operator's
+main ~/.hermes. The home gets a derived ``config.yaml`` (Cartesia TTS+STT wired
+to the profile's endpoint/models), an ``.env`` seeded from ~/.hermes/.env with
+the resolved ``CARTESIA_BASE_URL`` upserted, the Cartesia plugin symlinked in,
+and ``auth.json`` symlinked so the driving LLM reuses existing auth.
+
+Never prints secrets. Internal endpoint hosts are resolved from machine-local
+env, never read from or written to committed files.
+
+Usage:
+    hermes_agents.py list
+    hermes_agents.py resolve <profile>        # JSON, host redacted
+    hermes_agents.py materialize <profile>    # prints HERMES_HOME path on stdout
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PLUGIN_DIR = SCRIPT_DIR / "plugins" / "cartesia"
+MAIN_HOME = Path.home() / ".hermes"
+# The canonical generic template always lives with the tool.
+TEMPLATE_PATH = SCRIPT_DIR / "profiles" / "TEMPLATE.yaml"
+
+# Profiles are loaded from a search PATH so they can live wherever they belong:
+# internal/work profiles in the work repo, public ones in the personal/tool
+# repos. First match wins on a name collision (like $PATH). Override the whole
+# path with HERMES_AGENT_PROFILE_PATH (os.pathsep-separated); otherwise these
+# defaults are searched (non-existent dirs are skipped).
+_DEFAULT_PROFILE_DIRS = [
+    Path.home() / "src" / "karan.hiremath" / "agentic" / "hermes" / "profiles",  # work / internal
+    Path.home() / "src" / "hermes" / "profiles",                                 # personal / public
+    SCRIPT_DIR / "profiles",                                                     # tooling (TEMPLATE)
+]
+
+
+def profile_path() -> list[Path]:
+    raw = os.environ.get("HERMES_AGENT_PROFILE_PATH")
+    if raw:
+        dirs = [Path(p).expanduser() for p in raw.split(os.pathsep) if p.strip()]
+    else:
+        dirs = list(_DEFAULT_PROFILE_DIRS)
+        legacy = os.environ.get("HERMES_AGENT_PROFILE_DIR")
+        if legacy:
+            dirs.insert(0, Path(legacy).expanduser())
+    seen: set[str] = set()
+    out: list[Path] = []
+    for d in dirs:
+        if not d.exists():
+            continue
+        key = str(d.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+
+
+def _source_label(path: Path) -> str:
+    # Match the repo dir specifically — not a bare username substring, since the
+    # home dir (/home/karan.hiremath) would make every path look like "work".
+    s = str(path)
+    if "/src/karan.hiremath/" in s:
+        return "work"
+    if "/src/hermes/" in s:
+        return "personal"
+    if "/src/profile/" in s:
+        return "profile"
+    return path.parent.name
+
+
+def find_profile(name: str) -> Path:
+    for d in profile_path():
+        cand = d / f"{name}.yaml"
+        if cand.exists():
+            return cand
+    searched = "\n  ".join(str(d) for d in profile_path()) or "(no profile dirs found)"
+    raise SystemExit(f"ERROR: no such profile: {name}. Searched:\n  {searched}")
+
+
+def _data_home() -> Path:
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / "hermes-agents"
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    """Parse a KEY=VALUE .env file. Tolerant: skips blanks/comments."""
+    out: Dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip()
+    return out
+
+
+def _resolve_env(key: str) -> Optional[str]:
+    """Resolve an env var from the shell first, then machine-local ~/.hermes/.env."""
+    if not key:
+        return None
+    if os.environ.get(key):
+        return os.environ[key]
+    return _read_env_file(MAIN_HOME / ".env").get(key)
+
+
+def load_profile(name: str) -> Dict[str, Any]:
+    path = find_profile(name)
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERROR: profile is not a mapping: {path}")
+    data.setdefault("name", name)
+    return data
+
+
+def voice_on(profile: Dict[str, Any]) -> bool:
+    """Whether this agent uses TTS/STT at all. Text-only agents (tts+stt both
+    disabled) need no Cartesia endpoint and skip all voice wiring."""
+    tts = profile.get("tts") or {}
+    stt = profile.get("stt") or {}
+    return bool(tts.get("enabled", True)) or bool(stt.get("enabled", True))
+
+
+def resolve_base_url(profile: Dict[str, Any], *, required: bool = True) -> Optional[str]:
+    ep = profile.get("endpoint") or {}
+    inline = (ep.get("base_url") or "").strip()
+    if inline:
+        return inline.rstrip("/")
+    env_key = (ep.get("base_url_env") or "").strip()
+    val = _resolve_env(env_key) if env_key else None
+    if not val:
+        if not required:
+            return None
+        raise SystemExit(
+            f"ERROR: profile '{profile.get('name')}' has no endpoint.base_url and "
+            f"env {env_key or '(unset)'} is empty. Set {env_key} in ~/.hermes/.env "
+            "(internal hosts stay machine-local), or set tts.enabled+stt.enabled "
+            "to false for a text-only agent."
+        )
+    return val.rstrip("/")
+
+
+def _redact_host(url: str) -> str:
+    # Show scheme + a hint, hide the full internal hostname in logs.
+    try:
+        scheme, _, rest = url.partition("://")
+        host = rest.split("/")[0]
+        if host in ("api.cartesia.ai",) or host.startswith("localhost") or host.startswith("127."):
+            return url  # public / local — fine to show
+        parts = host.split(".")
+        masked = (parts[0][:3] + "***") if parts else "***"
+        return f"{scheme}://{masked}.{'.'.join(parts[1:])}" if len(parts) > 1 else f"{scheme}://{masked}"
+    except Exception:
+        return "<redacted>"
+
+
+def _render_config(profile: Dict[str, Any]) -> Dict[str, Any]:
+    tts = profile.get("tts") or {}
+    stt = profile.get("stt") or {}
+    llm = profile.get("llm") or {}
+    tts_on = bool(tts.get("enabled", True))
+    stt_on = bool(stt.get("enabled", True))
+    voice = (tts.get("voice") or "").strip() or _resolve_env("CARTESIA_VOICE_ID") or ""
+
+    toolsets = list(profile.get("toolsets") or ["hermes-cli"])
+    if not tts_on and "tts" in toolsets:
+        toolsets.remove("tts")
+
+    cfg: Dict[str, Any] = {
+        "model": {
+            "provider": llm.get("provider", "openai-codex"),
+            "default": llm.get("model", "gpt-5.5"),
+        },
+        "toolsets": toolsets,
+        "plugins": {"enabled": ["cartesia"] if (tts_on or stt_on) else []},
+    }
+    if tts_on:
+        cfg["tts"] = {"provider": "cartesia", "model": tts.get("model", "sonic-3.5"), "voice": voice}
+    if stt_on:
+        cfg["stt"] = {
+            "enabled": True,
+            "provider": "cartesia",
+            "cartesia": {"model": stt.get("model", "ink-2"), "language": stt.get("language", "en")},
+        }
+    else:
+        cfg["stt"] = {"enabled": False}
+    return cfg
+
+
+def _upsert_env(path: Path, updates: Dict[str, str]) -> None:
+    """Write/refresh .env: seed from ~/.hermes/.env on first create, then upsert
+    only the managed keys so manual edits (platform tokens) survive."""
+    existing_lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else None
+    if existing_lines is None:
+        # First create: seed from main .env (CARTESIA_API_KEY + platform tokens).
+        seed = MAIN_HOME / ".env"
+        existing_lines = seed.read_text(encoding="utf-8").splitlines() if seed.exists() else [
+            "# Managed by profile/bin/hermes/agents. Machine-local; do not commit.",
+        ]
+    keys = set(updates)
+    kept = [ln for ln in existing_lines if ln.partition("=")[0].strip() not in keys]
+    managed = [f"{k}={v}" for k, v in updates.items() if v]
+    path.write_text("\n".join(kept + managed) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def materialize(name: str) -> Path:
+    profile = load_profile(name)
+    uses_voice = voice_on(profile)
+    base_url = resolve_base_url(profile, required=uses_voice)
+    home = _data_home() / name
+    home.mkdir(parents=True, exist_ok=True)
+    home.chmod(0o700)
+
+    cfg = _render_config(profile)
+    # config.yaml — always regenerated (fully derived from the profile).
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    # SOUL.md — persona.
+    persona = (profile.get("persona") or "").strip()
+    if persona:
+        (home / "SOUL.md").write_text(persona + "\n", encoding="utf-8")
+
+    # .env — seed from main once, then upsert managed keys on every run. The
+    # API key always re-syncs from ~/.hermes/.env so adding it later propagates;
+    # non-managed keys (e.g. gateway platform tokens) are preserved. Voice keys
+    # are written only for voice-enabled agents.
+    env_updates: Dict[str, str] = {}
+    if uses_voice:
+        if base_url:
+            env_updates["CARTESIA_BASE_URL"] = base_url
+        api_key = _resolve_env("CARTESIA_API_KEY")
+        if api_key:
+            env_updates["CARTESIA_API_KEY"] = api_key
+        voice = cfg.get("tts", {}).get("voice")
+        if voice:
+            env_updates["CARTESIA_VOICE_ID"] = voice
+    _upsert_env(home / ".env", env_updates)
+
+    # plugin — symlink the canonical profile-repo copy into this home (only when
+    # the agent actually uses voice).
+    if uses_voice:
+        plugins = home / "plugins"
+        plugins.mkdir(exist_ok=True)
+        link = plugins / "cartesia"
+        if link.is_symlink():
+            link.unlink()
+        if not link.exists():
+            link.symlink_to(PLUGIN_DIR)
+
+    # auth.json — reuse the operator's LLM auth without re-login.
+    main_auth = MAIN_HOME / "auth.json"
+    home_auth = home / "auth.json"
+    if main_auth.exists() and not home_auth.exists():
+        home_auth.symlink_to(main_auth)
+
+    return home
+
+
+def cmd_list() -> int:
+    # Merge across the path; first occurrence of a name wins (shadows later).
+    seen: set[str] = set()
+    rows = []
+    for d in profile_path():
+        for p in sorted(d.glob("*.yaml")):
+            if p.stem == "TEMPLATE" or p.stem in seen:
+                continue
+            seen.add(p.stem)
+            try:
+                prof = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            except Exception:
+                continue
+            if not voice_on(prof):
+                endpoint = "(text-only)"
+            else:
+                ep = prof.get("endpoint") or {}
+                inline = (ep.get("base_url") or "").strip()
+                env_key = (ep.get("base_url_env") or "").strip()
+                if inline:
+                    endpoint = inline
+                else:
+                    resolved = _resolve_env(env_key)
+                    endpoint = _redact_host(resolved) if resolved else f"(unset: {env_key})"
+            home = _data_home() / p.stem
+            rows.append((
+                p.stem, _source_label(d), prof.get("surface", "cli"),
+                "ready" if home.exists() else "-", endpoint,
+            ))
+    w = max([len(r[0]) for r in rows] + [7]) if rows else 7
+    print(f"{'PROFILE':<{w}}  {'SOURCE':<8}  {'SURFACE':<8}  {'HOME':<5}  ENDPOINT")
+    for name, source, surface, ready, endpoint in rows:
+        print(f"{name:<{w}}  {source:<8}  {surface:<8}  {ready:<5}  {endpoint}")
+    return 0
+
+
+def cmd_resolve(name: str) -> int:
+    profile = load_profile(name)
+    uses_voice = voice_on(profile)
+    cfg = _render_config(profile)
+    out: Dict[str, Any] = {
+        "name": name,
+        "voice": uses_voice,
+        "surface": profile.get("surface", "cli"),
+        "platform": profile.get("platform", "telegram"),
+        "toolsets": cfg["toolsets"],
+        "home": str(_data_home() / name),
+    }
+    if uses_voice:
+        base_url = resolve_base_url(profile, required=False)
+        out["endpoint"] = _redact_host(base_url) if base_url else "(unset)"
+        if "tts" in cfg:
+            out["tts_model"] = cfg["tts"]["model"]
+            out["tts_voice"] = "set" if cfg["tts"]["voice"] else "(none)"
+        if cfg.get("stt", {}).get("enabled"):
+            out["stt_model"] = cfg["stt"]["cartesia"]["model"]
+    else:
+        out["endpoint"] = "(text-only)"
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__)
+        return 2
+    cmd, *rest = argv
+    if cmd == "list":
+        return cmd_list()
+    if cmd == "resolve":
+        if not rest:
+            raise SystemExit("ERROR: resolve needs a profile name")
+        return cmd_resolve(rest[0])
+    if cmd == "materialize":
+        if not rest:
+            raise SystemExit("ERROR: materialize needs a profile name")
+        print(materialize(rest[0]))
+        return 0
+    raise SystemExit(f"ERROR: unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/bin/hermes/plugins/.gitignore
+++ b/bin/hermes/plugins/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/bin/hermes/plugins/cartesia/__init__.py
+++ b/bin/hermes/plugins/cartesia/__init__.py
@@ -1,0 +1,34 @@
+"""Cartesia backend plugin: registers Sonic TTS + Ink STT providers.
+
+Enable per Hermes plugin gating (``plugins.enabled``), then select in
+config.yaml:
+
+    tts:
+      provider: cartesia
+      voice: <cartesia-voice-id>     # or set CARTESIA_VOICE_ID in ~/.hermes/.env
+      model: sonic-3.5               # optional; defaults to latest (sonic-3.5)
+    stt:
+      enabled: true
+      provider: cartesia
+      cartesia:
+        model: ink-2                 # optional; defaults to latest (ink-2)
+        language: en                 # optional
+
+Requires CARTESIA_API_KEY in ~/.hermes/.env.
+
+Endpoint (prod / staging / on-prem / in-cluster) is switched via
+CARTESIA_BASE_URL — the same env var the bifrost stack uses
+(default https://api.cartesia.ai). Same paths and key auth across
+environments. Internal hostnames belong in ~/.hermes/.env, never in this
+source (data boundary). See validate.py for an end-to-end endpoint check.
+"""
+
+from __future__ import annotations
+
+from .stt import CartesiaTranscriptionProvider
+from .tts import CartesiaTTSProvider
+
+
+def register(ctx) -> None:
+    ctx.register_tts_provider(CartesiaTTSProvider())
+    ctx.register_transcription_provider(CartesiaTranscriptionProvider())

--- a/bin/hermes/plugins/cartesia/_common.py
+++ b/bin/hermes/plugins/cartesia/_common.py
@@ -1,0 +1,83 @@
+"""Shared Cartesia HTTP plumbing for the TTS + STT providers.
+
+No vendor SDK dependency — talks to the Cartesia HTTP API directly via
+``httpx`` (already vendored in the Hermes toolchain venv). Credentials are
+read from ``~/.hermes/.env`` through Hermes' own ``get_env_value`` helper so
+the key never has to be exported into the process environment.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+BASE_URL_DEFAULT = "https://api.cartesia.ai"
+# Only value the API currently accepts; override via env for forward-compat.
+API_VERSION_DEFAULT = "2026-03-01"
+
+
+def get_env(key: str) -> Optional[str]:
+    """Read ``key`` from Hermes' env store, falling back to os.environ.
+
+    ``hermes_cli.config.get_env_value`` resolves ``~/.hermes/.env`` (where
+    ``hermes secrets`` / ``configure-machine`` write keys) in addition to the
+    process environment; prefer it so a non-exported ``.env`` entry works.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+
+        val = get_env_value(key)
+        if val:
+            return val
+    except Exception:
+        pass
+    return os.environ.get(key)
+
+
+def api_key() -> Optional[str]:
+    return get_env("CARTESIA_API_KEY")
+
+
+def base_url() -> str:
+    """Canonical Cartesia endpoint switch (matches the bifrost repo convention).
+
+    Default public prod; set ``CARTESIA_BASE_URL`` in ~/.hermes/.env to point at
+    an internal target for validation — e.g. shared staging, on-prem
+    (``http://localhost:8000``), or in-cluster (``http://api:8000``). The same
+    server, paths, and key auth serve every environment.
+    """
+    return (get_env("CARTESIA_BASE_URL") or BASE_URL_DEFAULT).rstrip("/")
+
+
+def stt_base_url() -> str:
+    """STT endpoint, with an optional STT-only override.
+
+    Mirrors inferno's ``CARTESIA_STT_BASE_URL`` / ``STT_BASE_URL`` convention so
+    STT can target a different stack than TTS when validating; falls back to the
+    shared :func:`base_url`.
+    """
+    return (
+        get_env("CARTESIA_STT_BASE_URL")
+        or get_env("STT_BASE_URL")
+        or base_url()
+    ).rstrip("/")
+
+
+def api_version() -> str:
+    return get_env("CARTESIA_VERSION") or API_VERSION_DEFAULT
+
+
+def auth_headers() -> Dict[str, str]:
+    key = api_key()
+    if not key:
+        raise RuntimeError(
+            "CARTESIA_API_KEY is not set. Add it to ~/.hermes/.env "
+            "(get a key at https://play.cartesia.ai/console)."
+        )
+    # Cartesia's model API (public + internal apps/api) canonically takes the
+    # key in X-API-Key; Authorization: Bearer is also accepted. X-API-Key
+    # matches the in-repo callers (inferno/s2s/stt.py, lora_app/create_voice.py).
+    return {
+        "X-API-Key": key,
+        "Cartesia-Version": api_version(),
+    }

--- a/bin/hermes/plugins/cartesia/plugin.yaml
+++ b/bin/hermes/plugins/cartesia/plugin.yaml
@@ -1,0 +1,7 @@
+name: cartesia
+version: 1.0.0
+description: "Cartesia TTS (Sonic) + STT (Ink) backend for Hermes. Registers a TTSProvider (tts.provider: cartesia) and a TranscriptionProvider (stt.provider: cartesia) over the Cartesia HTTP API."
+author: Karan Hiremath
+kind: backend
+requires_env:
+  - CARTESIA_API_KEY

--- a/bin/hermes/plugins/cartesia/stt.py
+++ b/bin/hermes/plugins/cartesia/stt.py
@@ -1,0 +1,115 @@
+"""Cartesia speech-to-text provider (Ink / ink-whisper).
+
+Routes ``transcribe_audio`` calls when ``stt.provider: cartesia``. The
+dispatcher passes ``model`` (from ``stt.cartesia.model``) and ``language``
+(from ``stt.cartesia.language`` / ``stt.language``); both fall back to
+provider defaults. Returns the standard ``{success, transcript, provider}``
+envelope and never raises (per the TranscriptionProvider contract).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.transcription_provider import TranscriptionProvider
+
+from ._common import auth_headers, get_env, stt_base_url
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "ink-2"  # latest; override via stt.cartesia.model / CARTESIA_STT_MODEL
+DEFAULT_LANGUAGE = "en"
+HTTP_TIMEOUT = 300.0
+
+
+class CartesiaTranscriptionProvider(TranscriptionProvider):
+    @property
+    def name(self) -> str:
+        return "cartesia"
+
+    @property
+    def display_name(self) -> str:
+        return "Cartesia"
+
+    def is_available(self) -> bool:
+        return bool(get_env("CARTESIA_API_KEY"))
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Cartesia",
+            "badge": "paid",
+            "tag": "Ink — streaming STT (ink-whisper)",
+            "env_vars": [
+                {
+                    "key": "CARTESIA_API_KEY",
+                    "prompt": "Cartesia API key",
+                    "url": "https://play.cartesia.ai/console",
+                },
+            ],
+        }
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {"id": "ink-2", "display": "Ink 2 (latest)"},
+            {"id": "ink-whisper", "display": "Ink Whisper"},
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return get_env("CARTESIA_STT_MODEL") or DEFAULT_MODEL
+
+    def transcribe(
+        self,
+        file_path: str,
+        *,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        **extra: Any,
+    ) -> Dict[str, Any]:
+        if not os.path.isfile(file_path):
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"audio file not found: {file_path}",
+                "provider": self.name,
+            }
+
+        model_id = model or self.default_model()
+        lang = language or get_env("CARTESIA_LANGUAGE") or DEFAULT_LANGUAGE
+        data = {"model": model_id, "language": lang}
+
+        try:
+            with open(file_path, "rb") as fh:
+                files = {"file": (os.path.basename(file_path), fh, "application/octet-stream")}
+                with httpx.Client(timeout=HTTP_TIMEOUT) as client:
+                    resp = client.post(
+                        f"{stt_base_url()}/stt",
+                        headers=auth_headers(),
+                        data=data,
+                        files=files,
+                    )
+            if resp.status_code >= 400:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "error": f"Cartesia STT HTTP {resp.status_code}: {resp.text[:500]}",
+                    "provider": self.name,
+                }
+            payload = resp.json()
+        except Exception as exc:  # noqa: BLE001 — contract: never raise
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Cartesia STT request failed: {exc}",
+                "provider": self.name,
+            }
+
+        transcript = payload.get("text", "") if isinstance(payload, dict) else ""
+        return {
+            "success": True,
+            "transcript": transcript or "",
+            "provider": self.name,
+        }

--- a/bin/hermes/plugins/cartesia/tts.py
+++ b/bin/hermes/plugins/cartesia/tts.py
@@ -1,0 +1,187 @@
+"""Cartesia text-to-speech provider (Sonic models).
+
+Routes ``text_to_speech`` tool calls when ``tts.provider: cartesia``. The
+dispatcher (``tools.tts_tool._dispatch_to_plugin_provider``) reads
+``tts.voice`` / ``tts.model`` / ``tts.speed`` / ``tts.output_format`` from
+config.yaml and passes them here; anything omitted falls back to env defaults
+(``CARTESIA_VOICE_ID`` / ``CARTESIA_TTS_MODEL``) then to provider defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.tts_provider import TTSProvider
+
+from ._common import auth_headers, base_url, get_env
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "sonic-3.5"  # latest stable (rolling); override via tts.model / CARTESIA_TTS_MODEL
+DEFAULT_SAMPLE_RATE = 44100
+DEFAULT_BIT_RATE = 128000
+HTTP_TIMEOUT = 60.0
+
+
+def _output_format(fmt: str, sample_rate: int) -> Dict[str, Any]:
+    """Map a Hermes format token to a Cartesia ``output_format`` object.
+
+    Cartesia containers are mp3 / wav / raw. mp3 and wav are produced
+    natively; ogg/opus/flac aren't Cartesia containers, so we emit mp3 and
+    let the gateway's ffmpeg voice-bubble pass re-encode if needed.
+    """
+    f = (fmt or "mp3").lower()
+    if f == "wav":
+        return {
+            "container": "wav",
+            "encoding": "pcm_s16le",
+            "sample_rate": sample_rate,
+        }
+    return {
+        "container": "mp3",
+        "sample_rate": sample_rate,
+        "bit_rate": DEFAULT_BIT_RATE,
+    }
+
+
+class CartesiaTTSProvider(TTSProvider):
+    @property
+    def name(self) -> str:
+        return "cartesia"
+
+    @property
+    def display_name(self) -> str:
+        return "Cartesia"
+
+    def is_available(self) -> bool:
+        return bool(get_env("CARTESIA_API_KEY"))
+
+    @property
+    def voice_compatible(self) -> bool:
+        # mp3/wav output re-encodes cleanly to Opus for voice bubbles.
+        return True
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Cartesia",
+            "badge": "paid",
+            "tag": "Sonic — ultra-low-latency TTS",
+            "env_vars": [
+                {
+                    "key": "CARTESIA_API_KEY",
+                    "prompt": "Cartesia API key",
+                    "url": "https://play.cartesia.ai/console",
+                },
+            ],
+        }
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {"id": "sonic-3.5", "display": "Sonic 3.5 (latest)"},
+            {"id": "sonic-3", "display": "Sonic 3"},
+            {"id": "sonic-latest", "display": "Sonic (rolling latest alias)"},
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return get_env("CARTESIA_TTS_MODEL") or DEFAULT_MODEL
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        """Best-effort voice catalog via GET /voices. Empty on any error."""
+        try:
+            headers = auth_headers()
+        except Exception:
+            return []
+        out: List[Dict[str, Any]] = []
+        try:
+            with httpx.Client(timeout=HTTP_TIMEOUT) as client:
+                resp = client.get(
+                    f"{base_url()}/voices",
+                    headers=headers,
+                    params={"limit": 100},
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+            rows = payload.get("data", payload) if isinstance(payload, dict) else payload
+            for v in rows or []:
+                if not isinstance(v, dict) or not v.get("id"):
+                    continue
+                out.append(
+                    {
+                        "id": v["id"],
+                        "display": v.get("name") or v["id"],
+                        "language": v.get("language"),
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — catalog is advisory
+            logger.debug("Cartesia list_voices failed: %s", exc)
+        return out
+
+    def default_voice(self) -> Optional[str]:
+        env_voice = get_env("CARTESIA_VOICE_ID")
+        if env_voice:
+            return env_voice
+        voices = self.list_voices()
+        return voices[0]["id"] if voices else None
+
+    def synthesize(
+        self,
+        text: str,
+        output_path: str,
+        *,
+        voice: Optional[str] = None,
+        model: Optional[str] = None,
+        speed: Optional[float] = None,
+        format: str = "mp3",
+        **extra: Any,
+    ) -> str:
+        if not get_env("CARTESIA_API_KEY"):
+            raise RuntimeError(
+                "CARTESIA_API_KEY is not set. Add it to ~/.hermes/.env "
+                "(get a key at https://play.cartesia.ai/console)."
+            )
+        voice_id = voice or self.default_voice()
+        if not voice_id:
+            raise RuntimeError(
+                "No Cartesia voice configured. Set tts.voice in config.yaml "
+                "or CARTESIA_VOICE_ID in ~/.hermes/.env (list ids with the "
+                "Cartesia console / GET /voices)."
+            )
+        model_id = model or self.default_model()
+        try:
+            sample_rate = int(get_env("CARTESIA_SAMPLE_RATE") or DEFAULT_SAMPLE_RATE)
+        except ValueError:
+            sample_rate = DEFAULT_SAMPLE_RATE
+
+        body: Dict[str, Any] = {
+            "model_id": model_id,
+            "transcript": text,
+            "voice": {"mode": "id", "id": voice_id},
+            "output_format": _output_format(format, sample_rate),
+        }
+        language = get_env("CARTESIA_LANGUAGE")
+        if language:
+            body["language"] = language
+        if isinstance(speed, (int, float)):
+            # Cartesia generation_config.speed is clamped to [0.6, 1.5].
+            body["generation_config"] = {"speed": max(0.6, min(1.5, float(speed)))}
+
+        with httpx.Client(timeout=HTTP_TIMEOUT) as client:
+            resp = client.post(
+                f"{base_url()}/tts/bytes",
+                headers={**auth_headers(), "Content-Type": "application/json"},
+                json=body,
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Cartesia TTS HTTP {resp.status_code}: {resp.text[:500]}"
+                )
+            audio = resp.content
+
+        if not audio:
+            raise RuntimeError("Cartesia TTS returned empty audio.")
+        with open(output_path, "wb") as fh:
+            fh.write(audio)
+        return output_path

--- a/bin/hermes/plugins/cartesia/validate.py
+++ b/bin/hermes/plugins/cartesia/validate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Standalone validation for the Cartesia Hermes plugin.
+
+Exercises the *currently configured* endpoint (public, staging, on-prem, or
+in-cluster) end to end without going through Hermes. Reads the same env as the
+plugin — set CARTESIA_BASE_URL / CARTESIA_API_KEY / CARTESIA_VOICE_ID in
+~/.hermes/.env (or export them) before running. Never prints the API key.
+
+Run with the toolchain venv python:
+
+    ~/.local/share/hermes-toolchain/venv/bin/python \\
+        ~/.hermes/plugins/cartesia/validate.py            # config + connectivity
+    ... validate.py --tts                                  # synth roundtrip
+    ... validate.py --tts --stt                            # synth then transcribe back
+
+Examples of pointing at internal targets (keep hosts in ~/.hermes/.env):
+    CARTESIA_BASE_URL=https://staging-api.cartesia.ai
+    CARTESIA_BASE_URL=http://localhost:8000      # on-prem docker-compose
+    CARTESIA_BASE_URL=http://api:8000            # in-cluster (ClusterIP)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# Import the plugin as a package (its modules use relative imports).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cartesia._common import api_version, base_url, get_env, stt_base_url  # noqa: E402
+from cartesia.stt import CartesiaTranscriptionProvider  # noqa: E402
+from cartesia.tts import CartesiaTTSProvider  # noqa: E402
+
+
+def _ok(msg: str) -> None:
+    print(f"  ok   {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  FAIL {msg}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate the Cartesia plugin endpoint.")
+    ap.add_argument("--tts", action="store_true", help="synthesize a short phrase")
+    ap.add_argument("--stt", action="store_true", help="transcribe the synthesized clip (implies --tts)")
+    ap.add_argument("--text", default="Cartesia validation check, one two three.")
+    args = ap.parse_args()
+    if args.stt:
+        args.tts = True
+
+    tts = CartesiaTTSProvider()
+    stt = CartesiaTranscriptionProvider()
+
+    print("config")
+    print(f"  tts_endpoint   {base_url()}/tts/bytes")
+    print(f"  stt_endpoint   {stt_base_url()}/stt")
+    print(f"  api_version    {api_version()}")
+    print(f"  api_key        {'set' if get_env('CARTESIA_API_KEY') else 'MISSING'}")
+    print(f"  tts_model      {tts.default_model()}")
+    print(f"  stt_model      {stt.default_model()}")
+    print(f"  voice          {get_env('CARTESIA_VOICE_ID') or '(none in env — will use first /voices result)'}")
+
+    failures = 0
+
+    print("connectivity")
+    voices = tts.list_voices()
+    if voices:
+        _ok(f"GET /voices -> {len(voices)} voices (e.g. {voices[0]['id']})")
+    else:
+        _fail("GET /voices returned nothing (bad key, endpoint, or no voices on this stack)")
+        failures += 1
+
+    clip = None
+    if args.tts:
+        print("tts")
+        out = os.path.join(os.environ.get("TMPDIR", "/tmp"), "cartesia_validate.mp3")
+        try:
+            t0 = time.monotonic()
+            tts.synthesize(args.text, out, format="mp3")
+            dt = (time.monotonic() - t0) * 1000
+            size = os.path.getsize(out)
+            _ok(f"synthesize -> {size} bytes in {dt:.0f} ms ({out})")
+            clip = out
+        except Exception as exc:  # noqa: BLE001
+            _fail(f"synthesize raised: {exc}")
+            failures += 1
+
+    if args.stt:
+        print("stt")
+        if not clip:
+            _fail("no clip to transcribe (tts step failed)")
+            failures += 1
+        else:
+            t0 = time.monotonic()
+            res = stt.transcribe(clip)
+            dt = (time.monotonic() - t0) * 1000
+            if res.get("success"):
+                _ok(f"transcribe -> {res.get('transcript')!r} in {dt:.0f} ms")
+            else:
+                _fail(f"transcribe: {res.get('error')}")
+                failures += 1
+
+    print("PASS" if failures == 0 else f"FAILED ({failures})")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/hermes/profiles/TEMPLATE.yaml
+++ b/bin/hermes/profiles/TEMPLATE.yaml
@@ -1,0 +1,37 @@
+# Hermes voice agent profile.
+# Copy to <name>.yaml (or run `agents new <name>`) and edit.
+#
+# Data boundary: this file is committed to the profile repo (both machines).
+# Do NOT hardcode internal/staging hostnames or secrets here. Point at an
+# internal endpoint via `endpoint.base_url_env` and keep the actual host +
+# CARTESIA_API_KEY in machine-local ~/.hermes/.env.
+
+name: TEMPLATE
+description: "What this agent validates."
+
+endpoint:
+  # Resolution order at launch: base_url (if non-empty) wins, else the value of
+  # the env var named by base_url_env (read from ~/.hermes/.env or the shell).
+  base_url: ""                     # OK to inline ONLY public/non-sensitive hosts
+  base_url_env: CARTESIA_BASE_URL  # internal hosts live here, machine-local
+
+tts:
+  model: sonic-3.5                 # latest
+  voice: ""                        # empty -> resolved from CARTESIA_VOICE_ID
+
+stt:
+  model: ink-2                     # latest
+  language: en
+
+llm:                               # the model driving the agent itself
+  provider: openai-codex
+  model: gpt-5.5
+
+surface: cli                       # default surface: cli | tui | gateway
+platform: telegram                 # used when surface=gateway
+toolsets:
+  - hermes-cli
+
+persona: |
+  You are a helpful voice assistant in my terminal. Keep replies short, natural,
+  and easy to speak aloud. Be direct and skip filler.

--- a/myprofile.sh
+++ b/myprofile.sh
@@ -216,6 +216,66 @@ _pc_completions() {
 }
 compdef _pc_completions pc
 
+# Completions for the Hermes `agents` launcher (subcommands + profile names from
+# the profile search path).
+_agents_completions() {
+    local -a subcmds profiles dirs
+    subcmds=(
+        "list:list profiles, source, surface, endpoint"
+        "resolve:show a profile's resolved config"
+        "new:scaffold a new profile from TEMPLATE"
+        "check:materialize + endpoint health check"
+        "up:launch an agent (cli/tui/gateway)"
+        "help:show help"
+    )
+    if [[ -n "$HERMES_AGENT_PROFILE_PATH" ]]; then
+        dirs=(${(s/:/)HERMES_AGENT_PROFILE_PATH})
+    else
+        dirs=(
+            "$HOME/src/karan.hiremath/agentic/hermes/profiles"
+            "$HOME/src/hermes/profiles"
+            "$HOME/src/profile/bin/hermes/profiles"
+        )
+    fi
+    local d f
+    for d in $dirs; do
+        [[ -d "$d" ]] || continue
+        for f in "$d"/*.yaml(N); do
+            [[ "${f:t:r}" == TEMPLATE ]] && continue
+            profiles+="${f:t:r}"
+        done
+    done
+    profiles=(${(u)profiles})  # dedupe across the search path
+
+    if (( CURRENT == 2 )); then
+        _describe 'agents command' subcmds
+        return
+    fi
+    case "${words[2]}" in
+        resolve|check)
+            _describe 'profile' profiles ;;
+        up)
+            if (( CURRENT == 3 )); then
+                _describe 'profile' profiles
+            else
+                _arguments \
+                    '--surface[launch surface]:surface:(cli tui gateway)' \
+                    '--platform[gateway platform]:platform:(telegram discord whatsapp weixin)' \
+                    '--check[health-check the endpoint before launching]'
+            fi ;;
+        new)
+            if (( CURRENT == 3 )); then
+                _message 'new profile name'
+            else
+                _arguments '--dir[target repo]:dir:(work personal profile)'
+            fi ;;
+    esac
+}
+compdef _agents_completions agents
+
+# Hermes voice/agent launcher (profiles -> isolated agents; CLI/TUI/gateway)
+alias agents="$HOME/src/profile/bin/hermes/agents"
+
 # Source work-specific extensions if present
 # karan.hiremath provides: tc (training clusters), ic (inference clusters), dashboard
 [ -f "$HOME/src/karan.hiremath/scripts/shell-ext.sh" ] && source "$HOME/src/karan.hiremath/scripts/shell-ext.sh"


### PR DESCRIPTION
Day-to-day tooling under `bin/hermes/` to run isolated Hermes voice agents from declarative profiles in terminal / tmux / TUI (and messaging) workflows. Each agent runs in its own `HERMES_HOME` and never touches your main `~/.hermes`.

- `agents` launcher: bring a profile up as a **CLI**, **TUI** (`herm`), or **messaging gateway** (Telegram/Discord/WhatsApp/…)
- `hermes_agents.py`: profile-search-path resolution + isolated-home materialization (config, plugin symlink, auth reuse, `.env` derivation)
- `plugins/cartesia`: Sonic-3.5 TTS + Ink-2 STT provider (httpx, no SDK); endpoint switchable via `CARTESIA_BASE_URL`; `validate.py` for a quick endpoint health check
- `profiles/TEMPLATE.yaml` + README

Profiles load from a search path so each lives where it belongs (personal in `~/src/hermes`, this repo for the generic `TEMPLATE`; internal ones stay in the work repo). No secrets or internal hosts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)