### PR TITLE
Add personal agent-config sync (agentic-sync)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,6 +101,14 @@ obsidian:
     export APP_BIN="${PROFILE_DIR}/bin"
     ./bin/obsidian/install
 
+# Personal agent-config sync (symlinks + pull-only cron). Safe on the work Mac.
+agentic-sync:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PROFILE_DIR="$(pwd)"
+    export APP_BIN="${PROFILE_DIR}/bin"
+    ./bin/agentic-sync/install
+
 zsh:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/bin/agentic-sync/agentic-sync
+++ b/bin/agentic-sync/agentic-sync
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# agentic-sync — git-backed, pull-only sync of personal agent config.
+#
+# Mirrors the work agentic-workstation pattern for personal machines:
+#   - source of truth: this `profile` repo (synced to all personal machines)
+#   - cron action: fetch + ff-only pull ONLY when the worktree is clean, then
+#     apply safe symlinks from a manifest.
+#   - never auto-commits, auto-pushes, or syncs auth/secrets/sessions/caches.
+#
+# Profile detection is keyed on work-repo presence so this never fights the
+# work sync over the same target paths:
+#   - ~/src/karan.hiremath present  -> "minimal" (keep profile pulled; do NOT
+#                                       touch agent config — the work sync owns it)
+#   - absent (e.g. the Mac Mini)    -> "full"    (apply personal agent config)
+# Override anytime via --profile / AGENTIC_SYNC_PROFILE / host.env.
+
+set -euo pipefail
+
+DEFAULT_REPO_URL="https://github.com/karanhiremath/profile.git"
+DEFAULT_REPO_DIR="${HOME}/src/profile"
+WORK_REPO_DIR="${HOME}/src/karan.hiremath"
+STATE_DIR="${HOME}/.local/state/agentic-sync"
+LOG_FILE="${STATE_DIR}/sync.log"
+CRON_BEGIN="# BEGIN agentic-sync"
+CRON_END="# END agentic-sync"
+
+repo_url="${AGENTIC_SYNC_REPO_URL:-$DEFAULT_REPO_URL}"
+repo_dir="${AGENTIC_SYNC_REPO_DIR:-$DEFAULT_REPO_DIR}"
+manifest=""
+profile="${AGENTIC_SYNC_PROFILE:-}"
+dry_run=0
+assume_yes=0
+command_name="run"
+
+usage() {
+  cat <<'EOF'
+Usage: agentic-sync [options] [command]
+
+Commands:
+  run             pull repo if clean, then apply symlinks (default)
+  status          print repo/link/cron status
+  pull            clone/fetch/ff-only pull repo; skip dirty worktrees
+  link            apply manifest symlinks only
+  install-cron    install user crontab entry for run (every 20 min)
+  uninstall-cron  remove user crontab entry
+  cron-status     show matching crontab block
+
+Options:
+  --repo-dir DIR       repo checkout path (default: ~/src/profile)
+  --repo-url URL       clone URL if repo is absent
+  --manifest FILE      manifest path (default: <repo>/bin/agentic-sync/manifest.tsv)
+  --profile PROFILE    full|minimal|none (default: auto by work-repo presence)
+  --dry-run            print actions without mutating files/crontab
+  -y, --yes            replace existing targets with timestamped backups without prompting
+  -h, --help           show help
+
+Host overrides are read from:
+  /etc/agentic-sync/host.env
+  ~/.config/agentic-sync/host.env
+EOF
+}
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+run_cmd() {
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'dry-run:'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+load_host_env() {
+  local env_file
+  for env_file in /etc/agentic-sync/host.env "${HOME}/.config/agentic-sync/host.env"; do
+    if [ -r "$env_file" ]; then
+      # shellcheck disable=SC1090
+      . "$env_file"
+    fi
+  done
+  repo_url="${AGENTIC_SYNC_REPO_URL:-$repo_url}"
+  repo_dir="${AGENTIC_SYNC_REPO_DIR:-$repo_dir}"
+  profile="${AGENTIC_SYNC_PROFILE:-$profile}"
+}
+
+# Personal machines get the full personal agent config; machines that also hold
+# the work repo defer agent-config links to the work sync to avoid clobbering.
+detect_profile() {
+  if [ -n "$profile" ]; then
+    printf '%s\n' "$profile"
+    return
+  fi
+  if [ -d "${WORK_REPO_DIR}/.git" ]; then
+    printf 'minimal\n'
+  else
+    printf 'full\n'
+  fi
+}
+
+expand_path() {
+  local path="$1"
+  path="${path/#\~/$HOME}"
+  path="${path//\$HOME/$HOME}"
+  path="${path//\$REPO_DIR/$repo_dir}"
+  printf '%s\n' "$path"
+}
+
+secret_path_guard() {
+  local path="$1"
+  case "$path" in
+    *auth.json*|*.env|*.env.*|*/.env|*/credentials|*/credentials/*|*kubeconfig*|*history.jsonl*|*logs_*.sqlite*|*.sqlite|*.sqlite-shm|*.sqlite-wal|*/sessions/*|*/cache/*|*/log/*|*/logs/*)
+      log "refusing secret/runtime path: $path"
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+manifest_path() {
+  if [ -n "$manifest" ]; then
+    printf '%s\n' "$manifest"
+  else
+    printf '%s\n' "${repo_dir}/bin/agentic-sync/manifest.tsv"
+  fi
+}
+
+ensure_repo() {
+  if [ -d "${repo_dir}/.git" ]; then
+    return 0
+  fi
+  log "repo absent; cloning $repo_url -> $repo_dir"
+  run_cmd mkdir -p "$(dirname "$repo_dir")"
+  run_cmd git clone "$repo_url" "$repo_dir"
+}
+
+repo_dirty() {
+  [ -n "$(git -C "$repo_dir" status --porcelain --untracked-files=normal 2>/dev/null || true)" ]
+}
+
+pull_repo() {
+  ensure_repo
+  if repo_dirty; then
+    log "repo dirty; fetch only, skip pull: $repo_dir"
+    run_cmd git -C "$repo_dir" fetch --quiet origin
+    return 0
+  fi
+  log "repo clean; ff-only pull: $repo_dir"
+  run_cmd git -C "$repo_dir" fetch --quiet origin
+  run_cmd git -C "$repo_dir" pull --ff-only --quiet
+}
+
+profile_matches() {
+  local profiles="$1" active="$2"
+  case ",$profiles," in
+    *,all,*|*,"$active",*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+backup_existing() {
+  local target="$1"
+  local backup
+  backup="${target}.backup.$(date -u '+%Y%m%dT%H%M%SZ')"
+  if [ "$assume_yes" -ne 1 ] && [ ! -t 0 ]; then
+    log "non-interactive and --yes missing; refusing to replace $target"
+    return 1
+  fi
+  if [ "$assume_yes" -ne 1 ]; then
+    printf 'Replace %s with symlink? Existing path will move to %s [y/N] ' "$target" "$backup" >&2
+    local answer
+    read -r answer
+    case "$answer" in
+      y|Y|yes|YES) ;;
+      *) log "skipped $target"; return 1 ;;
+    esac
+  fi
+  log "backup $target -> $backup"
+  run_cmd mv "$target" "$backup"
+}
+
+link_one() {
+  local target="$1" source="$2" mode="$3" note="$4"
+  local target_path source_path target_parent
+  target_path="$(expand_path "$target")"
+  source_path="$(expand_path "$source")"
+  case "$source_path" in
+    /*) ;;
+    *) source_path="${repo_dir}/${source_path}" ;;
+  esac
+
+  secret_path_guard "$target_path" || return 0
+  secret_path_guard "$source_path" || return 0
+
+  if [ ! -e "$source_path" ]; then
+    log "missing source; skip $target_path <- $source_path"
+    return 0
+  fi
+
+  if [ -L "$target_path" ]; then
+    local current
+    current="$(readlink "$target_path")"
+    if [ "$current" = "$source_path" ]; then
+      log "linked ok: $target_path"
+      return 0
+    fi
+    log "replace symlink: $target_path ($current -> $source_path)"
+    run_cmd rm "$target_path"
+  elif [ -e "$target_path" ]; then
+    if [ "$mode" = "copy" ]; then
+      log "copy over existing: $target_path ($note)"
+      run_cmd cp "$source_path" "$target_path"
+      return 0
+    fi
+    backup_existing "$target_path" || return 0
+  fi
+
+  target_parent="$(dirname "$target_path")"
+  run_cmd mkdir -p "$target_parent"
+  case "$mode" in
+    link|dir-link)
+      log "link: $target_path -> $source_path ($note)"
+      run_cmd ln -s "$source_path" "$target_path"
+      ;;
+    copy)
+      log "copy: $source_path -> $target_path ($note)"
+      run_cmd cp "$source_path" "$target_path"
+      ;;
+    *)
+      log "unknown mode '$mode'; skip $target_path"
+      ;;
+  esac
+}
+
+apply_links() {
+  ensure_repo
+  local mf active_profile
+  mf="$(manifest_path)"
+  active_profile="$(detect_profile)"
+  if [ "$active_profile" = "none" ]; then
+    log "profile=none; no links applied"
+    return 0
+  fi
+  if [ ! -f "$mf" ]; then
+    log "missing manifest: $mf"
+    return 1
+  fi
+  log "apply links: profile=$active_profile manifest=$mf"
+
+  local enabled profiles target source mode note
+  while IFS='|' read -r enabled profiles target source mode note; do
+    case "${enabled:-}" in ''|'#'*) continue ;; esac
+    [ "$enabled" = "1" ] || continue
+    profile_matches "$profiles" "$active_profile" || continue
+    link_one "$target" "$source" "$mode" "${note:-}"
+  done < "$mf"
+}
+
+cron_line() {
+  printf '3,23,43 * * * * /usr/bin/env bash %q run >> %q 2>&1\n' "${repo_dir}/bin/agentic-sync/agentic-sync" "$LOG_FILE"
+}
+
+install_cron() {
+  mkdir -p "$STATE_DIR"
+  local tmp
+  tmp="$(mktemp)"
+  (crontab -l 2>/dev/null || true) | awk -v begin="$CRON_BEGIN" -v end="$CRON_END" '
+    $0 == begin {skip=1; next}
+    $0 == end {skip=0; next}
+    skip != 1 {print}
+  ' > "$tmp"
+  {
+    printf '%s\n' "$CRON_BEGIN"
+    cron_line
+    printf '%s\n' "$CRON_END"
+  } >> "$tmp"
+  if [ "$dry_run" -eq 1 ]; then
+    cat "$tmp"
+  else
+    crontab "$tmp"
+    log "installed crontab block"
+  fi
+  rm -f "$tmp"
+}
+
+uninstall_cron() {
+  local tmp
+  tmp="$(mktemp)"
+  (crontab -l 2>/dev/null || true) | awk -v begin="$CRON_BEGIN" -v end="$CRON_END" '
+    $0 == begin {skip=1; next}
+    $0 == end {skip=0; next}
+    skip != 1 {print}
+  ' > "$tmp"
+  if [ "$dry_run" -eq 1 ]; then
+    cat "$tmp"
+  else
+    crontab "$tmp"
+    log "removed crontab block"
+  fi
+  rm -f "$tmp"
+}
+
+cron_status() {
+  (crontab -l 2>/dev/null || true) | awk -v begin="$CRON_BEGIN" -v end="$CRON_END" '
+    $0 == begin {show=1}
+    show == 1 {print}
+    $0 == end {show=0}
+  '
+}
+
+status() {
+  local active_profile mf
+  active_profile="$(detect_profile)"
+  mf="$(manifest_path)"
+  printf 'repo_dir: %s\n' "$repo_dir"
+  printf 'repo_url: %s\n' "$repo_url"
+  printf 'work_repo: %s\n' "$([ -d "${WORK_REPO_DIR}/.git" ] && echo present || echo absent)"
+  printf 'profile: %s\n' "$active_profile"
+  printf 'manifest: %s\n' "$mf"
+  if [ -d "${repo_dir}/.git" ]; then
+    printf 'repo: present\n'
+    if repo_dirty; then
+      printf 'repo_dirty: yes\n'
+    else
+      printf 'repo_dirty: no\n'
+    fi
+  else
+    printf 'repo: absent\n'
+  fi
+  printf 'cron:\n'
+  cron_status | sed 's/^/  /' || true
+}
+
+main() {
+  load_host_env
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo-dir) repo_dir="$2"; shift 2 ;;
+      --repo-url) repo_url="$2"; shift 2 ;;
+      --manifest) manifest="$2"; shift 2 ;;
+      --profile) profile="$2"; shift 2 ;;
+      --dry-run) dry_run=1; shift ;;
+      -y|--yes) assume_yes=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      run|status|pull|link|install-cron|uninstall-cron|cron-status) command_name="$1"; shift ;;
+      *) printf 'unknown arg: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+
+  case "$command_name" in
+    run) pull_repo; apply_links ;;
+    status) status ;;
+    pull) pull_repo ;;
+    link) apply_links ;;
+    install-cron) install_cron ;;
+    uninstall-cron) uninstall_cron ;;
+    cron-status) cron_status ;;
+  esac
+}
+
+main "$@"

--- a/bin/agentic-sync/host.env.example
+++ b/bin/agentic-sync/host.env.example
@@ -1,0 +1,12 @@
+# agentic-sync host overrides.
+# Copy to ~/.config/agentic-sync/host.env (or /etc/agentic-sync/host.env) and edit.
+# All optional — defaults auto-detect by work-repo presence.
+
+# Force a profile regardless of detection: full | minimal | none
+# AGENTIC_SYNC_PROFILE=full
+
+# Override repo checkout location (default: ~/src/profile)
+# AGENTIC_SYNC_REPO_DIR="$HOME/src/profile"
+
+# Override clone URL used only if the repo is absent
+# AGENTIC_SYNC_REPO_URL="git@github.com:karanhiremath/profile.git"

--- a/bin/agentic-sync/install
+++ b/bin/agentic-sync/install
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# install — set up personal agent-config sync (agentic-sync).
+#
+# Previews what would change, applies the manifest symlinks, and installs the
+# pull-only cron job so personal agent config self-updates from this repo.
+# Safe on the work Mac: detection yields profile=minimal there, so no agent
+# config is touched (the work sync keeps ownership).
+
+set -euo pipefail
+shopt -s failglob
+
+if [ -z "${PROFILE_DIR:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export PROFILE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+if [ -z "${APP_BIN:-}" ]; then
+    export APP_BIN="${PROFILE_DIR}/bin"
+fi
+
+SYNC="${APP_BIN}/agentic-sync/agentic-sync"
+
+INSTALL_CRON=1
+ASSUME_YES=0
+
+usage() {
+    cat <<EOF
+install — set up personal agent-config sync.
+
+USAGE
+    ./bin/agentic-sync/install [--no-cron] [-y|--yes] [--help]
+
+OPTIONS
+    --no-cron     Apply symlinks but do not install the cron job.
+    -y, --yes     Replace existing config files (timestamped backup) without prompting.
+    --help        Show this help.
+
+WHAT IT DOES
+    1. Prints current status (repo, detected profile, manifest).
+    2. Dry-run preview of the symlink actions.
+    3. Applies the manifest symlinks.
+    4. Installs the pull-only cron job (unless --no-cron).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-cron) INSTALL_CRON=0; shift ;;
+        -y|--yes)  ASSUME_YES=1; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+chmod +x "$SYNC"
+
+echo "=== status ==="
+"$SYNC" status
+
+echo
+echo "=== dry-run preview ==="
+"$SYNC" --dry-run link
+
+echo
+echo "=== applying symlinks ==="
+if [[ "$ASSUME_YES" -eq 1 ]]; then
+    "$SYNC" --yes link
+else
+    "$SYNC" link
+fi
+
+if [[ "$INSTALL_CRON" -eq 1 ]]; then
+    echo
+    echo "=== installing cron (pull-only, every 20 min) ==="
+    "$SYNC" install-cron
+    "$SYNC" cron-status
+else
+    echo
+    echo "Skipped cron install (--no-cron). Enable later with:"
+    echo "  ${SYNC} install-cron"
+fi
+
+echo
+echo "Done. Inspect anytime with: ${SYNC} status"

--- a/bin/agentic-sync/manifest.tsv
+++ b/bin/agentic-sync/manifest.tsv
@@ -1,0 +1,12 @@
+# enabled|profiles|target|source|mode|notes
+# profiles: all,full,minimal. mode: link,dir-link,copy.
+# 'full' applies only on machines WITHOUT ~/src/karan.hiremath (personal boxes);
+# on the work Mac these rows are skipped so the work sync keeps ownership.
+# Never add auth.json, .env, kubeconfigs, credential files, logs, sessions, sqlite, caches.
+1|full|~/.pi/agent/AGENTS.md|config/agents/AGENTS.md|link|pi global personal rules
+1|full|~/.pi/agent/AGENTIC_WORKFLOW.md|config/agents/AGENTIC_WORKFLOW.md|link|agentic execution loop
+1|full|~/.pi/agent/LANG_GO.md|config/agents/LANG_GO.md|link|Go conventions
+1|full|~/.pi/agent/LANG_PYTHON.md|config/agents/LANG_PYTHON.md|link|Python conventions
+1|full|~/.pi/agent/LANG_TYPESCRIPT.md|config/agents/LANG_TYPESCRIPT.md|link|TypeScript conventions
+1|full|~/.codex/AGENTS.md|config/agents/AGENTS.md|link|Codex global personal rules
+1|full|~/.claude/CLAUDE.md|config/agents/AGENTS.md|link|Claude Code global personal rules

--- a/config/agents/AGENTIC_WORKFLOW.md
+++ b/config/agents/AGENTIC_WORKFLOW.md
@@ -1,0 +1,17 @@
+# Agentic execution workflow (personal)
+
+Default loop for non-trivial work on personal machines.
+
+1. **Orient** — restate the goal in one line; locate the relevant files before editing.
+2. **Isolate** — for code changes, create a git worktree on a branch.
+3. **Plan** — for 3+ step work, track tasks; keep one in-progress at a time.
+4. **Act** — make the change; match surrounding code's idiom, naming, comment density.
+5. **Verify** — run it. Read real output/exit codes. Tests + lint where they exist.
+6. **Report** — terse summary (1-2 sentences). State what's done, what's unverified.
+
+## Parallelism
+- Independent reads/exploration: parallel. Dependent code changes: sequential through review.
+- Confirm before push/merge/publish/send unless pre-authorized.
+
+## When stuck
+- Don't thrash. Surface a blocker as `blocked: <what> / need: <decision>` and ask.

--- a/config/agents/AGENTS.md
+++ b/config/agents/AGENTS.md
@@ -1,0 +1,39 @@
+# Personal Agent Rules — Karan Hiremath
+
+Generic operating rules for coding agents (Claude Code, pi, Codex) on **personal**
+machines. No employer/customer/project context — that lives in separate work repos.
+Synced read-only from `profile` via `agentic-sync`.
+
+## Isolation / blast radius
+- Code changes go in a **git worktree** on a branch, never directly on the default branch.
+- Never mount or exfiltrate host credentials: SSH keys, cloud creds, kubeconfigs,
+  `auth.json`, browser profiles, 1Password, full `$HOME`.
+- Prefer read-only mounts for reference repos. Disposable HOME for containerized agents.
+- Confirm before irreversible / outward-facing actions (push, merge, publish, send).
+
+## Secrets
+- Never commit secrets or `.env` files. Never print access keys, tokens, or passwords.
+- If a secret is needed, reference an env var or a secrets manager — never inline.
+
+## Scripts & tools
+- Bash: `set -euo pipefail`, support `--help`. Write durable scripts; don't run
+  multi-step work as inline one-liners.
+- Every CLI tool ships `<tool> upgrade` (self-update) and bash+zsh completions.
+- Human-readable output: real newlines, progress, clean tables — never raw/escaped JSON.
+- Research existing OSS before building custom.
+
+## Git
+- Commit messages: imperative mood, name the affected component.
+- Branch first if on the default branch. Commit/push only when asked.
+
+## Output style
+- Treat output as billable bandwidth: terse, no tutorials, no restating tool output.
+- Represent uncertainty as fields (`unknown`, `needs-check`, `blocked`, `next`),
+  not metacognitive prose ("I realize", "I guess", "it seems like").
+
+## Verification
+- Read tool output directly. Don't chain `&& echo "..."` or pipe through `echo`/`printf`
+  for status — exit codes and unfiltered stdout speak.
+- Test locally before claiming done; report failures with the actual output.
+
+See language conventions in `LANG_*.md` and the execution loop in `AGENTIC_WORKFLOW.md`.

--- a/config/agents/LANG_GO.md
+++ b/config/agents/LANG_GO.md
@@ -1,0 +1,8 @@
+# Go conventions
+
+- `gofmt`/`goimports` clean; `go vet` and `golangci-lint` pass before done.
+- Errors: wrap with `fmt.Errorf("...: %w", err)`; never discard with `_` silently.
+- Context-first: `func(ctx context.Context, ...)` for anything I/O-bound.
+- Table-driven tests; `go test ./...` before claiming done.
+- Keep modules tidy: `go mod tidy`; pin tool deps via `go.mod`/`tools.go`.
+- Prefer the standard library; justify each third-party dependency.

--- a/config/agents/LANG_PYTHON.md
+++ b/config/agents/LANG_PYTHON.md
@@ -1,0 +1,9 @@
+# Python conventions
+
+- **Always `uv` + virtual environments.** Never bare `pip install`.
+  - `uv venv` / `uv pip install` / `uv run` / `uv sync`.
+- Target a pinned interpreter; commit `uv.lock` / `requirements.lock` for apps.
+- Lint+format with `ruff`; type-check with `mypy` or `pyright` where configured.
+- Prefer `pathlib`, `argparse`/`typer` for CLIs, `logging` over `print` in libraries.
+- Tools: importable module + thin CLI entrypoint; `--auto-approve` gate for destructive actions.
+- Tests with `pytest`; run before claiming done.

--- a/config/agents/LANG_TYPESCRIPT.md
+++ b/config/agents/LANG_TYPESCRIPT.md
@@ -1,0 +1,8 @@
+# TypeScript conventions
+
+- `strict: true`. No implicit `any`; prefer `unknown` + narrowing over casts.
+- Match the repo's package manager (pnpm/npm/yarn/bun) — check the lockfile first.
+- Lint+format with the repo's eslint/prettier/biome config; don't impose a new one.
+- Prefer explicit return types on exported functions; discriminated unions over enums.
+- Async: no floating promises; handle rejections. Validate external input (zod or equiv).
+- Run typecheck + tests (`tsc --noEmit`, vitest/jest) before claiming done.


### PR DESCRIPTION
Ports the work agentic-workstation pull-only sync pattern into `profile` for **personal** machines (Mac Mini + future personal boxes).

## What
- `bin/agentic-sync/agentic-sync` — generalized pull-only sync engine (clean-tree-gated, ff-only, `secret_path_guard`, backup-before-replace). No Cartesia defaults.
- `config/agents/` — fresh, **boundary-safe** personal agent config (AGENTS.md, LANG_{GO,PYTHON,TS}.md, AGENTIC_WORKFLOW.md). No work content.
- `bin/agentic-sync/manifest.tsv` — symlinks config into `~/.pi/agent`, `~/.codex`, `~/.claude`.
- `bin/agentic-sync/install` + `just agentic-sync` — apply symlinks + install pull-only cron.

## Boundary safety
Profile auto-detects on **work-repo presence**:
- `~/src/karan.hiremath` present (work Mac) → `minimal`: keeps profile pulled, **does not touch** agent config — the work sync keeps ownership. No clobber.
- absent (Mac Mini) → `full`: applies personal config.

Validated: detection returns `minimal` on the work Mac (link no-op) and all 7 rows render correctly under a clean HOME in `full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)