### PR TITLE
Add Omnigent toolkit integration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -224,6 +224,14 @@ devin:
     export APP_BIN="${PROFILE_DIR}/bin"
     ./bin/devin/install
 
+# Install/upgrade Omnigent
+omnigent:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PROFILE_DIR="$(pwd)"
+    export APP_BIN="${PROFILE_DIR}/bin"
+    ./bin/omnigent/install
+
 # Install/upgrade Gemini CLI
 gemini-cli:
     #!/usr/bin/env bash

--- a/bin/ai-toolkit/install-all
+++ b/bin/ai-toolkit/install-all
@@ -120,6 +120,16 @@ else
 fi
 echo ""
 
+# Omnigent
+echo "==> Installing/upgrading Omnigent..."
+if "${APP_BIN}/omnigent/install"; then
+    echo "✓ Omnigent completed successfully"
+else
+    echo "✗ Omnigent failed"
+    failed_installs+=("omnigent")
+fi
+echo ""
+
 # Gemini CLI
 echo "==> Installing/upgrading Gemini CLI..."
 if "${APP_BIN}/gemini-cli/install"; then

--- a/bin/nvim/lua/kh/agent_registry.lua
+++ b/bin/nvim/lua/kh/agent_registry.lua
@@ -1,0 +1,201 @@
+--- agent_registry.lua: Shared agent type definitions for fleet management.
+local M = {}
+
+M.VERSION = "1.1.0"
+
+M.agents = {
+  pi = {
+    type  = "pi",
+    label = "Pi Coding Agent",
+    icon  = "π",
+    color = "magenta",
+    detect = { cmds = { "node" }, title_pats = { "^π", "^✳", "^pi:" }, path_hints = { "pi" } },
+    spawn = { cmd = "pi", default_args = {}, continue_flag = "-c", project_flag = nil },
+    session = { dir = "~/.pi/agent/sessions", file_pattern = "*.jsonl" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Working", "Running", "Executing" },
+      waiting_pats = { "%$%d+%.%d+", "↑%d", "↓%d" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = false, session_file = true },
+  },
+
+  cursor = {
+    type  = "cursor",
+    label = "Cursor Agent",
+    icon  = "◆",
+    color = "cyan",
+    detect = {
+      cmds       = { "cursor-agent", "agent" },
+      title_pats = { "cursor", "Cursor", "Composer" },
+      path_hints = { "cursor-agent", "agent" },
+    },
+    spawn = {
+      cmd           = "cursor-agent",
+      default_args  = { "--model", "claude-opus-4-8-thinking-high" },
+      continue_flag = "--continue",
+      project_flag  = "--workspace",
+    },
+    session = {
+      dir          = "~/.cursor/projects",
+      file_pattern = "**/agent-transcripts/**/*.jsonl",
+    },
+    status = {
+      strategy     = "tui_capture",
+      working_pats = { "Thinking", "Running", "Executing", "Working" },
+      waiting_pats = { "^>", "❯" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+
+  claude = {
+    type  = "claude",
+    label = "Claude Code",
+    icon  = "C",
+    color = "cyan",
+    detect = { cmds = { "claude" }, title_pats = { "claude", "Claude" }, path_hints = { "claude" } },
+    spawn = { cmd = "claude", default_args = {}, continue_flag = "--continue", project_flag = nil },
+    session = { dir = "~/.claude/projects", file_pattern = "*.json" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Thinking", "Reading", "Editing", "Running", "Searching", "Writing", "Creating" },
+      waiting_pats = { "^>", "^❯", "What would you like" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+
+  codex = {
+    type  = "codex",
+    label = "Codex CLI",
+    icon  = "X",
+    color = "green",
+    detect = { cmds = { "codex" }, title_pats = { "codex", "Codex" }, path_hints = { "codex" } },
+    spawn = { cmd = "codex", default_args = {}, continue_flag = "", project_flag = nil },
+    session = { dir = "~/.codex", file_pattern = "*.json" },
+    status = {
+      strategy = "tui_capture",
+      working_pats = { "Thinking", "Running", "Executing" },
+      waiting_pats = { "^>", "❯" },
+    },
+    project_mgmt = { tracks_branch = true, worktree_iso = true, session_file = true },
+  },
+
+  omnigent = {
+    type  = "omnigent",
+    label = "Omnigent",
+    icon  = "O",
+    color = "red",
+    detect = {
+      cmds       = { "omni", "omnigent" },
+      title_pats = { "omni", "omnigent", "Omnigent" },
+      path_hints = { "omni", "omnigent" },
+    },
+    spawn = {
+      cmd           = "omni",
+      default_args  = { "run", "--harness", "claude-sdk", "--server", "" },
+      continue_flag = "--continue",
+      project_flag  = nil,
+    },
+    session = {
+      dir          = "~/.omnigent",
+      file_pattern = "chat.db",
+    },
+    status = {
+      strategy     = "tui_capture",
+      working_pats = { "Starting", "Preparing", "Connecting", "Launching", "Working", "Running" },
+      waiting_pats = { "^>", "❯" },
+    },
+    project_mgmt = { tracks_branch = false, worktree_iso = false, session_file = true },
+  },
+}
+
+M.order = { "pi", "cursor", "claude", "codex", "omnigent" }
+
+function M.get(agent_type) return M.agents[agent_type] end
+
+function M.all()
+  local result = {}
+  for _, key in ipairs(M.order) do
+    if M.agents[key] then result[#result + 1] = M.agents[key] end
+  end
+  return result
+end
+
+function M.available()
+  local result = {}
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    if agent then
+      for _, hint in ipairs(agent.detect.path_hints) do
+        if vim.fn.exepath(hint) ~= "" then
+          result[#result + 1] = agent
+          break
+        end
+      end
+    end
+  end
+  return result
+end
+
+function M.match_pane(cmd, title)
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    local cmd_match = false
+    for _, c in ipairs(agent.detect.cmds) do
+      if cmd == c then cmd_match = true; break end
+    end
+    if cmd_match then
+      if #agent.detect.title_pats > 0 then
+        for _, pat in ipairs(agent.detect.title_pats) do
+          if title:match(pat) then return agent end
+        end
+      else
+        return agent
+      end
+    end
+  end
+  for _, key in ipairs(M.order) do
+    local agent = M.agents[key]
+    for _, pat in ipairs(agent.detect.title_pats) do
+      if title:match(pat) then return agent end
+    end
+  end
+  return nil
+end
+
+function M.expand_path(path)
+  if not path then return nil end
+  return vim.fn.expand(path)
+end
+
+function M.spawn_cmd(agent_type, dir, extra_args)
+  local agent = M.agents[agent_type]
+  if not agent then return nil end
+  local bin = vim.fn.exepath(agent.spawn.cmd)
+  if bin == "" then bin = agent.spawn.cmd end
+  local parts = { bin }
+  for _, arg in ipairs(agent.spawn.default_args) do parts[#parts + 1] = arg end
+  if extra_args then
+    for _, arg in ipairs(extra_args) do parts[#parts + 1] = arg end
+  end
+  local cmd = table.concat(parts, " ")
+  if dir then cmd = "cd " .. vim.fn.shellescape(dir) .. " && " .. cmd end
+  return cmd
+end
+
+M.status_icons = { waiting = "⏳", working = "⚙️ ", init = "✳ ", idle = "💤", unknown = "❓" }
+
+function M.to_json()
+  return vim.fn.json_encode({ version = M.VERSION, agents = M.agents, order = M.order })
+end
+
+function M.export(path)
+  path = path or vim.fn.expand("~/.config/fleet/agent-registry.json")
+  local dir = vim.fn.fnamemodify(path, ":h")
+  vim.fn.mkdir(dir, "p")
+  local f = io.open(path, "w")
+  if f then f:write(M.to_json()); f:close(); return true end
+  return false
+end
+
+return M

--- a/bin/omnigent/README.md
+++ b/bin/omnigent/README.md
@@ -1,0 +1,59 @@
+# Omnigent profile integration
+
+Omnigent is a host-level agent/session runtime for terminalized harnesses such as Claude, Hermes, Pi, and direct `omni run` agents.
+
+## Install / upgrade
+
+```bash
+just omnigent
+```
+
+The installer uses:
+
+```bash
+uv tool install --python /usr/bin/python3.12 omnigent
+```
+
+Override the Python binary with `OMNIGENT_PYTHON=/path/to/python` if needed.
+
+## Personal-safe local default
+
+Use the local persistent server by passing an empty server URL:
+
+```bash
+omni server status
+omni host status --server ""
+omni run --harness claude-sdk --server ""
+omni claude --server ""
+omni hermes --server ""
+omni pi --server ""
+```
+
+## Doctor
+
+```bash
+bin/omnigent/doctor
+```
+
+The doctor prints only non-secret status: binary paths, version, config summary, server status, and host status. It does **not** read log bodies, `chat.db`, artifacts, transcripts, credentials, or session contents.
+
+## State boundary
+
+Shared profile tooling lives here in `~/src/profile`:
+
+- installer
+- doctor/status wrapper
+- generic launcher documentation
+- generic fleet/registry metadata
+
+Machine-local state stays out of git in `~/.omnigent`:
+
+- `config.yaml`
+- `chat.db*`
+- `logs/`
+- `artifacts/`
+- daemon/server metadata
+- host ids and session ids
+- remote server URLs or credentials
+
+Treat Omnigent logs, artifacts, and database rows as potentially sensitive transcript data. Inspect them only for an explicitly personal-scoped debugging task.

--- a/bin/omnigent/ROLLOUT.md
+++ b/bin/omnigent/ROLLOUT.md
@@ -1,0 +1,92 @@
+# Omnigent rollout checklist
+
+Use this to enable Omnigent consistently on each personal/dev machine.
+
+## 1. Pull profile tooling
+
+```bash
+cd ~/src/profile
+git pull --ff-only
+```
+
+## 2. Install or upgrade Omnigent
+
+```bash
+just omnigent
+```
+
+Expected output includes:
+
+```text
+omnigent 0.3.0
+omni=...
+omnigent=...
+Runtime state: ~/.omnigent (machine-local; do not commit)
+```
+
+If `/usr/bin/python3.12` is unavailable, set:
+
+```bash
+OMNIGENT_PYTHON=$(command -v python3) just omnigent
+```
+
+## 3. Start/verify the local server and host
+
+```bash
+omni server start
+omni host status --server ""
+bin/omnigent/doctor
+```
+
+If the host shows `offline` or launch requests time out:
+
+```bash
+omni host stop --server "" || true
+omni server stop || true
+omni server start
+omni host --server ""
+```
+
+For the long-running `omni host --server ""` command, keep it in a managed terminal/tmux pane, or launch it through your terminal supervisor. It is expected to keep running.
+
+## 4. Smoke test
+
+```bash
+omni run --harness claude-sdk --server "" --no-log -p \
+  "Personal-toolkit smoke test. Reply exactly: OK_OMNIGENT_PERSONAL_SMOKE"
+```
+
+Success is the exact response:
+
+```text
+OK_OMNIGENT_PERSONAL_SMOKE
+```
+
+## 5. Daily usage patterns
+
+Use Omnigent when you want persisted/resumable/forkable terminal-agent sessions:
+
+```bash
+omni run --harness claude-sdk --server ""
+omni run --harness codex --server ""
+omni claude --server ""
+omni hermes --server ""
+omni pi --server ""
+```
+
+Use direct CLIs for quick one-off tasks where Omnigent session persistence is unnecessary.
+
+## 6. State and boundary policy
+
+Keep these machine-local and out of git:
+
+- `~/.omnigent/config.yaml`
+- `~/.omnigent/chat.db*`
+- `~/.omnigent/logs/`
+- `~/.omnigent/artifacts/`
+- daemon metadata, host IDs, session IDs
+- credentials or remote server URLs
+
+Treat logs, artifacts, and database rows as transcript-bearing sensitive data. Inspect them only for an explicitly scoped debugging task.
+
+Personal profile default: always use the local server (`--server ""`). Work profiles must define their own work-data retention and remote-server policy inside the work boundary.

--- a/bin/omnigent/doctor
+++ b/bin/omnigent/doctor
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Non-secret Omnigent status check for personal/shared profile tooling.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bin/omnigent/doctor [--help]
+
+Prints non-secret Omnigent status. It intentionally avoids reading chat.db,
+artifacts, transcripts, or log bodies because those may contain personal/work
+session content.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  "") ;;
+  *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+esac
+
+if ! command -v omni >/dev/null 2>&1; then
+  echo "omni=missing"
+  exit 1
+fi
+if ! command -v omnigent >/dev/null 2>&1; then
+  echo "omnigent=missing"
+  exit 1
+fi
+
+printf 'omni=%s\n' "$(command -v omni)"
+printf 'omnigent=%s\n' "$(command -v omnigent)"
+printf 'version='; omni --version
+printf '\n-- config --\n'
+omni config list
+printf '\n-- server --\n'
+omni server status || true
+printf '\n-- local host --\n'
+omni host status --server "" || true

--- a/bin/omnigent/install
+++ b/bin/omnigent/install
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Install or upgrade Omnigent via uv tool into the user's local toolchain.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bin/omnigent/install [--help]
+
+Installs/upgrades Omnigent with uv tool, exposing both `omni` and `omnigent`.
+Runtime config/state stays machine-local in ~/.omnigent and is never committed.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  "") ;;
+  *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+esac
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv is required. Install uv first: https://docs.astral.sh/uv/getting-started/installation/" >&2
+  exit 1
+fi
+
+python_bin="${OMNIGENT_PYTHON:-/usr/bin/python3.12}"
+if [ ! -x "$python_bin" ]; then
+  python_bin="$(command -v python3.12 || command -v python3 || true)"
+fi
+if [ -z "$python_bin" ]; then
+  echo "ERROR: no python3.12/python3 found for uv tool install" >&2
+  exit 1
+fi
+
+echo "Installing/upgrading Omnigent with $python_bin..."
+uv tool install --python "$python_bin" omnigent
+
+echo ""
+omni --version
+printf 'omni=%s\n' "$(command -v omni)"
+printf 'omnigent=%s\n' "$(command -v omnigent)"
+echo "Runtime state: ~/.omnigent (machine-local; do not commit)"


### PR DESCRIPTION
## Summary
- add Omnigent installer, non-secret doctor, README, and rollout checklist
- wire `just omnigent` and AI toolkit install flow
- register Omnigent in the shared agent registry for fleet/terminal tooling

## Verification
- `just --list` shows `omnigent`
- `bin/omnigent/install --help`
- `bin/omnigent/doctor` reports Omnigent 0.3.0, local server, and online host
- `nvim --headless -u NONE -c 'luafile .../agent_registry.lua' ...` succeeds
- end-to-end smoke previously returned `OK_OMNIGENT_PERSONAL_SMOKE`

## Rollout
See `bin/omnigent/ROLLOUT.md` for per-machine setup and smoke-test steps.
