### PR TITLE
Add tmux PR review dashboard

### DIFF
--- a/bin/gh/ensure-gh-dash
+++ b/bin/gh/ensure-gh-dash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh is required before installing gh-dash" >&2
+  exit 127
+fi
+
+if gh extension list | grep -q '^gh dash[[:space:]]'; then
+  gh extension upgrade gh-dash || gh extension upgrade dash || true
+else
+  gh extension install dlvhdr/gh-dash
+fi

--- a/bin/gh/gh-dash/README.md
+++ b/bin/gh/gh-dash/README.md
@@ -1,0 +1,61 @@
+# gh-dash PR review
+
+Terminal-native GitHub PR review using the off-the-shelf [`dlvhdr/gh-dash`](https://github.com/dlvhdr/gh-dash) GitHub CLI extension.
+
+## Install
+
+```bash
+gh extension install dlvhdr/gh-dash
+```
+
+If already installed, upgrade with:
+
+```bash
+gh extension upgrade gh-dash
+```
+
+## Launch
+
+From any terminal:
+
+```bash
+gh dash --config ~/src/profile/bin/gh/gh-dash/config.yml
+```
+
+From tmux after installing/reloading `bin/tmux/tmux.conf`:
+
+- `prefix P` opens the dashboard in a horizontal pane
+- `prefix C-p` opens the dashboard in a full tmux window named `pr-review`
+
+The profile tmux prefix is `C-a`, so the common shortcuts are:
+
+```text
+C-a P
+C-a C-p
+```
+
+## Dashboard sections
+
+- `My PRs`: open PRs authored by `@me` under `karanhiremath/*`
+- `Needs My Review`: open PRs under `karanhiremath/*` requesting my review
+- `Hermes`: open PRs authored by me in `karanhiremath/hermes`
+- `Profile`: open PRs authored by me in `karanhiremath/profile`
+- `Notes`: open PRs authored by me in `karanhiremath/notes`
+
+## Useful gh-dash PR keys
+
+Inside the dashboard, press `?` for context-aware help.
+
+Common PR keys from gh-dash:
+
+- `d`: view PR diff using configured pager
+- `c`: comment on PR
+- `C`: checkout PR locally using `repoPaths`
+- `m`: merge PR via `gh pr merge`
+- `w`: watch PR checks
+- `e`: expand description
+- `q`: quit
+
+## Boundary
+
+This is intentionally an off-the-shelf GitHub TUI plus config. Do not grow a bespoke PR dashboard unless `gh-dash` and stock `gh` cannot support the workflow.

--- a/bin/gh/gh-dash/README.md
+++ b/bin/gh/gh-dash/README.md
@@ -30,10 +30,12 @@ From any terminal:
 ~/src/profile/bin/gh/pr-review
 ```
 
-which runs:
+The wrapper resolves paths relative to its checked-out profile repo, so it can also be smoke-tested from a PR worktree before merge.
+
+By default it runs:
 
 ```bash
-gh dash --config ~/src/profile/bin/gh/gh-dash/config.yml
+gh dash --config <profile-repo>/bin/gh/gh-dash/config.yml
 ```
 
 ## tmux project-review menu

--- a/bin/gh/gh-dash/README.md
+++ b/bin/gh/gh-dash/README.md
@@ -2,6 +2,8 @@
 
 Terminal-native GitHub PR review using the off-the-shelf [`dlvhdr/gh-dash`](https://github.com/dlvhdr/gh-dash) GitHub CLI extension.
 
+This setup intentionally uses `gh-dash` + stock `gh` instead of a bespoke PR dashboard.
+
 ## Install
 
 ```bash
@@ -14,18 +16,34 @@ If already installed, upgrade with:
 gh extension upgrade gh-dash
 ```
 
-## Launch
+The profile wrapper does this automatically when needed:
+
+```bash
+~/src/profile/bin/gh/ensure-gh-dash
+```
+
+## Direct launch
 
 From any terminal:
+
+```bash
+~/src/profile/bin/gh/pr-review
+```
+
+which runs:
 
 ```bash
 gh dash --config ~/src/profile/bin/gh/gh-dash/config.yml
 ```
 
-From tmux after installing/reloading `bin/tmux/tmux.conf`:
+## tmux project-review menu
 
-- `prefix P` opens the dashboard in a horizontal pane
-- `prefix C-p` opens the dashboard in a full tmux window named `pr-review`
+The tmux shortcut launches a context-aware project-review menu, not gh-dash directly.
+
+After installing/reloading `bin/tmux/tmux.conf`:
+
+- `prefix P` opens the reusable menu in a tmux popup
+- `prefix C-p` opens the same menu fullscreen in a tmux window
 
 The profile tmux prefix is `C-a`, so the common shortcuts are:
 
@@ -33,6 +51,20 @@ The profile tmux prefix is `C-a`, so the common shortcuts are:
 C-a P
 C-a C-p
 ```
+
+The menu starts a new tmux session with two panes:
+
+```text
+left:  Hermes project manager for the selected scope
+right: live gh-dash PR dashboard
+```
+
+Available menu scopes:
+
+- Personal project PR review: always available
+- Work project PR review: shown only when a `chief-of-staff-work` Hermes profile/home is detected on the host
+
+The left Hermes pane receives the right gh-dash pane id in `TMUX_PR_REVIEW_PANE`, so it can drive the live dashboard with `tmux send-keys` while also using `gh` commands for precise metadata/diffs/checks.
 
 ## Dashboard sections
 
@@ -58,4 +90,8 @@ Common PR keys from gh-dash:
 
 ## Boundary
 
-This is intentionally an off-the-shelf GitHub TUI plus config. Do not grow a bespoke PR dashboard unless `gh-dash` and stock `gh` cannot support the workflow.
+Personal PR review config includes only personal-safe repos. Work review is exposed only by the context-aware menu when the work Hermes profile exists on the host; work-specific data handling belongs to the work profile.
+
+## Future Linear integration
+
+Linear task views should also prefer off-the-shelf terminal tooling. Do not add Linear to this personal PR-review config until we have evaluated the available Linear CLI/TUI options and confirmed the correct data boundary for the current host/profile.

--- a/bin/gh/gh-dash/config.yml
+++ b/bin/gh/gh-dash/config.yml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://gh-dash.dev/schema.json
+# Karan's terminal-native PR review dashboard.
+# Launch with: gh dash --config ~/src/profile/bin/gh/gh-dash/config.yml
+
+prSections:
+  - title: My PRs
+    filters: >-
+      owner:karanhiremath
+      is:open
+      author:@me
+      archived:false
+      sort:updated-desc
+    limit: 50
+  - title: Needs My Review
+    filters: >-
+      owner:karanhiremath
+      is:open
+      review-requested:@me
+      -author:@me
+      archived:false
+      sort:updated-desc
+    limit: 50
+  - title: Hermes
+    filters: >-
+      repo:karanhiremath/hermes
+      is:open
+      author:@me
+      archived:false
+      sort:updated-desc
+    limit: 30
+  - title: Profile
+    filters: >-
+      repo:karanhiremath/profile
+      is:open
+      author:@me
+      archived:false
+      sort:updated-desc
+    limit: 30
+  - title: Notes
+    filters: >-
+      repo:karanhiremath/notes
+      is:open
+      author:@me
+      archived:false
+      sort:updated-desc
+    limit: 20
+
+issuesSections: []
+
+repoPaths:
+  karanhiremath/hermes: ~/src/hermes
+  karanhiremath/profile: ~/src/profile
+  karanhiremath/notes: ~/src/notes
+
+defaults:
+  view: prs
+  refetchIntervalMinutes: 5
+  prsLimit: 50
+  issuesLimit: 20
+  prApproveComment: LGTM
+  preview:
+    open: true
+    width: 50
+  layout:
+    prs:
+      repo:
+        width: 22
+      author:
+        hidden: true
+      base:
+        hidden: true
+      createdAt:
+        hidden: true
+      updatedAt:
+        width: 10
+      lines:
+        width: 10
+      reviewStatus:
+        width: 12
+      ci:
+        width: 10
+
+pager:
+  diff: less -R
+
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true
+theme:
+  ui:
+    sectionsShowCount: true
+    table:
+      compact: false
+      showSeparator: true

--- a/bin/gh/pr-review
+++ b/bin/gh/pr-review
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-config="${GH_DASH_CONFIG:-$HOME/src/profile/bin/gh/gh-dash/config.yml}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+profile_bin="$(cd -- "$script_dir/../.." && pwd)"
+config="${GH_DASH_CONFIG:-$profile_bin/bin/gh/gh-dash/config.yml}"
 
 if ! gh extension list | grep -q '^gh dash[[:space:]]'; then
-  "$HOME/src/profile/bin/gh/ensure-gh-dash"
+  "$profile_bin/bin/gh/ensure-gh-dash"
 fi
 
 exec gh dash --config "$config"

--- a/bin/gh/pr-review
+++ b/bin/gh/pr-review
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config="${GH_DASH_CONFIG:-$HOME/src/profile/bin/gh/gh-dash/config.yml}"
+
+if ! gh extension list | grep -q '^gh dash[[:space:]]'; then
+  "$HOME/src/profile/bin/gh/ensure-gh-dash"
+fi
+
+exec gh dash --config "$config"

--- a/bin/tmux/project-review-agent
+++ b/bin/tmux/project-review-agent
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scope="${1:-personal}"
+pr_pane="${2:-}"
+
+case "$scope" in
+  personal)
+    profile_name="chief-of-staff"
+    profile_home="$HOME/.local/share/hermes-agents/chief-of-staff/profiles/chief-of-staff"
+    title="Personal project review manager"
+    ;;
+  work)
+    profile_name="chief-of-staff-work"
+    profile_home="$HOME/.local/share/hermes-agents/chief-of-staff-work/profiles/chief-of-staff-work"
+    title="Work project review manager"
+    ;;
+  *)
+    echo "ERROR: unknown project-review scope: $scope" >&2
+    exit 2
+    ;;
+esac
+
+export TMUX_PR_REVIEW_SCOPE="$scope"
+export TMUX_PR_REVIEW_PANE="$pr_pane"
+
+if [ -d "$profile_home" ]; then
+  export HERMES_HOME="$profile_home"
+fi
+
+printf '%s\n' "$title"
+printf 'Profile: %s\n' "$profile_name"
+printf 'PR pane: %s\n\n' "${pr_pane:-unknown}"
+
+# Use the classic CLI for predictable tmux paste/input behavior.
+exec hermes chat --cli --source tmux-pr-review

--- a/bin/tmux/project-review-agent
+++ b/bin/tmux/project-review-agent
@@ -23,6 +23,24 @@ esac
 
 export TMUX_PR_REVIEW_SCOPE="$scope"
 export TMUX_PR_REVIEW_PANE="$pr_pane"
+export PATH="$HOME/.local/share/hermes-toolchain/npm/bin:$HOME/.local/bin:$PATH"
+
+hermes_bin="${HERMES_BIN:-}"
+if [ -z "$hermes_bin" ]; then
+  if command -v hermes >/dev/null 2>&1; then
+    hermes_bin="$(command -v hermes)"
+  else
+    for candidate in \
+      "$HOME/.local/share/hermes-toolchain/npm/bin/hermes" \
+      "$HOME/.local/bin/hermes"; do
+      if [ -x "$candidate" ]; then
+        hermes_bin="$candidate"
+        break
+      fi
+    done
+  fi
+fi
+[ -n "$hermes_bin" ] || { echo "ERROR: hermes not found. PATH=$PATH" >&2; exit 127; }
 
 if [ -d "$profile_home" ]; then
   export HERMES_HOME="$profile_home"
@@ -33,4 +51,4 @@ printf 'Profile: %s\n' "$profile_name"
 printf 'PR pane: %s\n\n' "${pr_pane:-unknown}"
 
 # Use the classic CLI for predictable tmux paste/input behavior.
-exec hermes chat --cli --source tmux-pr-review
+exec "$hermes_bin" chat --cli --source tmux-pr-review

--- a/bin/tmux/project-review-agent
+++ b/bin/tmux/project-review-agent
@@ -46,10 +46,10 @@ if [ -d "$profile_home" ]; then
   export HERMES_HOME="$profile_home"
 fi
 
-# In this two-pane review workflow, typed follow-ups should queue by default
-# instead of interrupting an in-flight project-manager turn. Allow override for
+# In this two-pane review workflow, typed follow-ups should steer by default
+# instead of interrupting an in-flight code-review turn. Allow override for
 # ad-hoc testing with HERMES_PROJECT_REVIEW_BUSY_INPUT_MODE=interrupt|steer|queue.
-busy_input_mode="${HERMES_PROJECT_REVIEW_BUSY_INPUT_MODE:-queue}"
+busy_input_mode="${HERMES_PROJECT_REVIEW_BUSY_INPUT_MODE:-steer}"
 if [ -n "${HERMES_HOME:-}" ]; then
   "$hermes_bin" config set display.busy_input_mode "$busy_input_mode" >/dev/null 2>&1 || true
 fi

--- a/bin/tmux/project-review-agent
+++ b/bin/tmux/project-review-agent
@@ -8,12 +8,12 @@ case "$scope" in
   personal)
     profile_name="chief-of-staff"
     profile_home="$HOME/.local/share/hermes-agents/chief-of-staff/profiles/chief-of-staff"
-    title="Personal project review manager"
+    title="Personal code review manager"
     ;;
   work)
     profile_name="chief-of-staff-work"
     profile_home="$HOME/.local/share/hermes-agents/chief-of-staff-work/profiles/chief-of-staff-work"
-    title="Work project review manager"
+    title="Work code review manager"
     ;;
   *)
     echo "ERROR: unknown project-review scope: $scope" >&2
@@ -46,9 +46,18 @@ if [ -d "$profile_home" ]; then
   export HERMES_HOME="$profile_home"
 fi
 
+# In this two-pane review workflow, typed follow-ups should queue by default
+# instead of interrupting an in-flight project-manager turn. Allow override for
+# ad-hoc testing with HERMES_PROJECT_REVIEW_BUSY_INPUT_MODE=interrupt|steer|queue.
+busy_input_mode="${HERMES_PROJECT_REVIEW_BUSY_INPUT_MODE:-queue}"
+if [ -n "${HERMES_HOME:-}" ]; then
+  "$hermes_bin" config set display.busy_input_mode "$busy_input_mode" >/dev/null 2>&1 || true
+fi
+
 printf '%s\n' "$title"
 printf 'Profile: %s\n' "$profile_name"
-printf 'PR pane: %s\n\n' "${pr_pane:-unknown}"
+printf 'PR pane: %s\n' "${pr_pane:-unknown}"
+printf 'Busy input: %s\n\n' "$busy_input_mode"
 
 # Use the classic CLI for predictable tmux paste/input behavior.
 exec "$hermes_bin" chat --cli --source tmux-pr-review

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -4,12 +4,14 @@ set -euo pipefail
 MODE="popup"
 SELECT=""
 TARGET_CLIENT=""
+TMUX_MENU=0
 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --mode) MODE="$2"; shift 2 ;;
     --select) SELECT="$2"; shift 2 ;;
     --client) TARGET_CLIENT="$2"; shift 2 ;;
+    --tmux-menu) TMUX_MENU=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --list) SELECT="__list__"; shift ;;
     -h|--help)
@@ -78,6 +80,20 @@ print_options() {
     echo "2) Work project PR review"
   fi
   echo "q) Quit"
+}
+
+show_tmux_menu() {
+  command -v tmux >/dev/null 2>&1 || { echo "ERROR: tmux not found" >&2; exit 127; }
+  [ -n "$TARGET_CLIENT" ] || TARGET_CLIENT="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
+  [ -n "$TARGET_CLIENT" ] || { echo "ERROR: no tmux client target available" >&2; exit 1; }
+
+  menu_cmd=(tmux display-menu -c "$TARGET_CLIENT" -T "Project Review")
+  menu_cmd+=("Personal project PR review" p "run-shell '$0 --select personal --client \"$TARGET_CLIENT\"'")
+  if have_work_profile; then
+    menu_cmd+=("Work project PR review" w "run-shell '$0 --select work --client \"$TARGET_CLIENT\"'")
+  fi
+  menu_cmd+=("" "" "" "Cancel" q "")
+  "${menu_cmd[@]}"
 }
 
 launch_session() {
@@ -154,6 +170,11 @@ EOF
     tmux attach-session -t "$session"
   fi
 }
+
+if [ "$TMUX_MENU" -eq 1 ]; then
+  show_tmux_menu
+  exit 0
+fi
 
 if [ "$SELECT" = "__list__" ]; then
   print_options

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="popup"
+SELECT=""
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --select) SELECT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --list) SELECT="__list__"; shift ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: project-review-menu [--mode popup|window|inline] [--select personal|work] [--dry-run] [--list]
+
+Context-aware tmux launcher for project review sessions.
+Creates a new tmux session with:
+  left pane: Hermes project manager
+  right pane: gh-dash PR review
+
+Work review appears only when a work Hermes profile is present on the host.
+USAGE
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+profile_bin="$HOME/src/profile"
+pr_review_cmd="$profile_bin/bin/gh/pr-review"
+agent_cmd="$profile_bin/bin/tmux/project-review-agent"
+
+have_work_profile() {
+  [ -d "$HOME/.local/share/hermes-agents/chief-of-staff-work/profiles/chief-of-staff-work" ] && return 0
+  [ -d "$HOME/.local/share/hermes-agents/chief-of-staff-work" ] && return 0
+  if [ -x "$HOME/src/profile/bin/hermes/agents" ]; then
+    "$HOME/src/profile/bin/hermes/agents" list 2>/dev/null | awk '{print $1}' | grep -qx 'chief-of-staff-work' && return 0
+  fi
+  return 1
+}
+
+print_options() {
+  echo "Project review menu ($MODE)"
+  echo
+  echo "1) Personal project PR review"
+  if have_work_profile; then
+    echo "2) Work project PR review"
+  fi
+  echo "q) Quit"
+}
+
+launch_session() {
+  scope="$1"
+  session="${TMUX_PROJECT_REVIEW_SESSION:-project-review-$scope-$(date +%Y%m%d-%H%M%S)}"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY RUN"
+    echo "scope=$scope"
+    echo "session=$session"
+    echo "left=$agent_cmd $scope <right-pane>"
+    echo "right=$pr_review_cmd"
+    return 0
+  fi
+
+  command -v tmux >/dev/null 2>&1 || { echo "ERROR: tmux not found" >&2; exit 127; }
+  command -v hermes >/dev/null 2>&1 || { echo "ERROR: hermes not found" >&2; exit 127; }
+  command -v gh >/dev/null 2>&1 || { echo "ERROR: gh not found" >&2; exit 127; }
+  [ -x "$pr_review_cmd" ] || { echo "ERROR: missing executable $pr_review_cmd" >&2; exit 127; }
+  [ -x "$agent_cmd" ] || { echo "ERROR: missing executable $agent_cmd" >&2; exit 127; }
+
+  tmux new-session -d -s "$session" -n review -c "$HOME" "$agent_cmd $scope"
+  left_pane="$(tmux list-panes -t "$session:review" -F '#{pane_id}' | head -n1)"
+  right_pane="$(tmux split-window -h -t "$session:review" -c "$HOME/src/profile" -P -F '#{pane_id}' "$pr_review_cmd")"
+  tmux resize-pane -t "$left_pane" -x 55%
+
+  # Restart the left pane with the right pane id injected so Hermes can drive gh-dash.
+  tmux respawn-pane -k -t "$left_pane" "$agent_cmd $scope '$right_pane'"
+  tmux select-pane -t "$left_pane"
+
+  prompt_file="$(mktemp "${TMPDIR:-/tmp}/project-review-prompt.XXXXXX")"
+  if [ "$scope" = "work" ]; then
+    boundary="WORK PROFILE. Use work-profile rules and do not copy work-private details into personal notes or repos."
+    title="work project manager"
+  else
+    boundary="PERSONAL ONLY. Do not read ~/src/karan.hiremath, Linear, work dailies, internal Slack, infra, customer data, security findings, or secrets."
+    title="personal project manager"
+  fi
+  cat >"$prompt_file" <<EOF
+You are the $title for a terminal-native tmux PR review session.
+
+Context:
+- The live PR dashboard is in the tmux pane target: $right_pane.
+- The dashboard is gh-dash, not a bespoke PR UI.
+- Help Karan review PRs without leaving tmux.
+- You may inspect PR metadata/diffs/checks using gh commands.
+- You may navigate the gh-dash pane when useful with commands like:
+  tmux send-keys -t '$right_pane' Down
+  tmux send-keys -t '$right_pane' Up
+  tmux send-keys -t '$right_pane' d
+  tmux send-keys -t '$right_pane' q
+- Prefer off-the-shelf GitHub tooling (gh-dash + gh). Do not build a bespoke PR dashboard.
+
+Boundary:
+$boundary
+
+Start by briefly orienting Karan: explain that the Hermes project manager is on the left, the live PR dashboard is on the right, you can drive it via tmux/gh, and ask which PR/project he wants to review first. Keep responses concise and action-oriented.
+EOF
+
+  # Give Hermes a moment to start, then paste the boot prompt into the left pane.
+  ( sleep 3
+    tmux load-buffer -b project-review-prompt "$prompt_file"
+    tmux paste-buffer -b project-review-prompt -t "$left_pane"
+    tmux send-keys -t "$left_pane" Enter
+    rm -f "$prompt_file"
+  ) >/dev/null 2>&1 &
+
+  if [ -n "${TMUX:-}" ]; then
+    tmux switch-client -t "$session"
+  else
+    tmux attach-session -t "$session"
+  fi
+}
+
+if [ "$SELECT" = "__list__" ]; then
+  print_options
+  exit 0
+fi
+
+if [ -n "$SELECT" ]; then
+  case "$SELECT" in
+    personal) launch_session personal ;;
+    work)
+      if have_work_profile; then
+        launch_session work
+      else
+        echo "Work project review is not available on this host (chief-of-staff-work profile not detected)." >&2
+        exit 1
+      fi
+      ;;
+    *) echo "unknown selection: $SELECT" >&2; exit 2 ;;
+  esac
+  exit 0
+fi
+
+print_options
+printf '\nSelect: '
+read -r choice
+case "$choice" in
+  1|p|P|personal) launch_session personal ;;
+  2|w|W|work)
+    if have_work_profile; then
+      launch_session work
+    else
+      echo "Work project review is not available on this host."
+      sleep 2
+    fi
+    ;;
+  q|Q|'') exit 0 ;;
+  *) echo "Unknown choice: $choice"; sleep 2; exit 2 ;;
+esac

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -4,6 +4,7 @@ set -euo pipefail
 MODE="popup"
 SELECT=""
 TARGET_CLIENT=""
+ATTACH_MODE="switch"
 TMUX_MENU=0
 DRY_RUN=0
 while [ $# -gt 0 ]; do
@@ -11,6 +12,7 @@ while [ $# -gt 0 ]; do
     --mode) MODE="$2"; shift 2 ;;
     --select) SELECT="$2"; shift 2 ;;
     --client) TARGET_CLIENT="$2"; shift 2 ;;
+    --attach) ATTACH_MODE="$2"; shift 2 ;;
     --tmux-menu) TMUX_MENU=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --list) SELECT="__list__"; shift ;;
@@ -88,9 +90,9 @@ show_tmux_menu() {
   [ -n "$TARGET_CLIENT" ] || { echo "ERROR: no tmux client target available" >&2; exit 1; }
 
   menu_cmd=(tmux display-menu -c "$TARGET_CLIENT" -T "Project Review")
-  menu_cmd+=("Personal project PR review" p "run-shell '$0 --select personal --client \"$TARGET_CLIENT\"'")
+  menu_cmd+=("Personal code review" p "run-shell '$0 --select personal --client \"$TARGET_CLIENT\" --attach popup'")
   if have_work_profile; then
-    menu_cmd+=("Work project PR review" w "run-shell '$0 --select work --client \"$TARGET_CLIENT\"'")
+    menu_cmd+=("Work code review" w "run-shell '$0 --select work --client \"$TARGET_CLIENT\" --attach popup'")
   fi
   menu_cmd+=("" "" "" "Cancel" q "")
   "${menu_cmd[@]}"
@@ -105,6 +107,7 @@ launch_session() {
     echo "scope=$scope"
     echo "session=$session"
     echo "client=${TARGET_CLIENT:-<current>}"
+    echo "attach=$ATTACH_MODE"
     echo "left=$agent_cmd $scope <right-pane>"
     echo "right=$pr_review_cmd"
     return 0
@@ -128,17 +131,17 @@ launch_session() {
   prompt_file="$(mktemp "${TMPDIR:-/tmp}/project-review-prompt.XXXXXX")"
   if [ "$scope" = "work" ]; then
     boundary="WORK PROFILE. Use work-profile rules and do not copy work-private details into personal notes or repos."
-    title="work project manager"
+    title="work code review manager"
   else
     boundary="PERSONAL ONLY. Do not read ~/src/karan.hiremath, Linear, work dailies, internal Slack, infra, customer data, security findings, or secrets."
-    title="personal project manager"
+    title="personal code review manager"
   fi
   cat >"$prompt_file" <<EOF
-You are the $title for a terminal-native tmux PR review session.
+You are the $title for a terminal-native tmux code review session.
 
 Context:
-- The live PR dashboard is in the tmux pane target: $right_pane.
-- The dashboard is gh-dash, not a bespoke PR UI.
+- You are in the left pane as the Hermes TUI code review/profile manager.
+- The live PR review TUI (gh-dash) is in the right pane target: $right_pane.
 - Help Karan review PRs without leaving tmux.
 - You may inspect PR metadata/diffs/checks using gh commands.
 - You may navigate the gh-dash pane when useful with commands like:
@@ -151,7 +154,7 @@ Context:
 Boundary:
 $boundary
 
-Start by briefly orienting Karan: explain that the Hermes project manager is on the left, the live PR dashboard is on the right, you can drive it via tmux/gh, and ask which PR/project he wants to review first. Keep responses concise and action-oriented.
+Start by briefly orienting Karan: explain that the Hermes code review manager is on the left, the live PR review TUI is on the right, you can drive it via tmux/gh, and ask which PR/project he wants to review first. Keep responses concise and action-oriented.
 EOF
 
   # Give Hermes a moment to start, then paste the boot prompt into the left pane.
@@ -162,7 +165,14 @@ EOF
     rm -f "$prompt_file"
   ) >/dev/null 2>&1 &
 
-  if [ -n "$TARGET_CLIENT" ]; then
+  if [ "$ATTACH_MODE" = "popup" ]; then
+    [ -n "$TARGET_CLIENT" ] || TARGET_CLIENT="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
+    if [ -n "$TARGET_CLIENT" ]; then
+      tmux display-popup -c "$TARGET_CLIENT" -E -w 95% -h 90% "tmux attach-session -t '$session'"
+    else
+      tmux display-popup -E -w 95% -h 90% "tmux attach-session -t '$session'"
+    fi
+  elif [ -n "$TARGET_CLIENT" ]; then
     tmux switch-client -c "$TARGET_CLIENT" -t "$session"
   elif [ -n "${TMUX:-}" ]; then
     tmux switch-client -t "$session"

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -3,11 +3,13 @@ set -euo pipefail
 
 MODE="popup"
 SELECT=""
+TARGET_CLIENT=""
 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --mode) MODE="$2"; shift 2 ;;
     --select) SELECT="$2"; shift 2 ;;
+    --client) TARGET_CLIENT="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --list) SELECT="__list__"; shift ;;
     -h|--help)
@@ -26,6 +28,10 @@ USAGE
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
+
+# If a popup/window launch fails, keep the UI open long enough to see the error
+# instead of silently disappearing.
+trap 'code=$?; if [ "$code" -ne 0 ] && [ -t 0 ]; then echo; echo "project-review-menu failed (exit $code)"; echo "Press Enter to close"; read -r _ || true; fi' EXIT
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 profile_bin="$(cd -- "$script_dir/../.." && pwd)"
@@ -59,6 +65,7 @@ launch_session() {
     echo "DRY RUN"
     echo "scope=$scope"
     echo "session=$session"
+    echo "client=${TARGET_CLIENT:-<current>}"
     echo "left=$agent_cmd $scope <right-pane>"
     echo "right=$pr_review_cmd"
     return 0
@@ -116,7 +123,9 @@ EOF
     rm -f "$prompt_file"
   ) >/dev/null 2>&1 &
 
-  if [ -n "${TMUX:-}" ]; then
+  if [ -n "$TARGET_CLIENT" ]; then
+    tmux switch-client -c "$TARGET_CLIENT" -t "$session"
+  elif [ -n "${TMUX:-}" ]; then
     tmux switch-client -t "$session"
   else
     tmux attach-session -t "$session"

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -38,6 +38,29 @@ profile_bin="$(cd -- "$script_dir/../.." && pwd)"
 pr_review_cmd="$profile_bin/bin/gh/pr-review"
 agent_cmd="$profile_bin/bin/tmux/project-review-agent"
 
+# tmux popups inherit the tmux server environment, which can be much smaller
+# than the interactive shell PATH. Include Hermes' profile-managed toolchain.
+export PATH="$HOME/.local/share/hermes-toolchain/npm/bin:$HOME/.local/bin:$PATH"
+
+resolve_hermes() {
+  if command -v hermes >/dev/null 2>&1; then
+    command -v hermes
+    return 0
+  fi
+  for candidate in \
+    "$HOME/.local/share/hermes-toolchain/npm/bin/hermes" \
+    "$HOME/.local/bin/hermes" \
+    "$HOME/src/profile/bin/hermes/hermes"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+hermes_bin="$(resolve_hermes || true)"
+
 have_work_profile() {
   [ -d "$HOME/.local/share/hermes-agents/chief-of-staff-work/profiles/chief-of-staff-work" ] && return 0
   [ -d "$HOME/.local/share/hermes-agents/chief-of-staff-work" ] && return 0
@@ -72,18 +95,18 @@ launch_session() {
   fi
 
   command -v tmux >/dev/null 2>&1 || { echo "ERROR: tmux not found" >&2; exit 127; }
-  command -v hermes >/dev/null 2>&1 || { echo "ERROR: hermes not found" >&2; exit 127; }
-  command -v gh >/dev/null 2>&1 || { echo "ERROR: gh not found" >&2; exit 127; }
+  [ -n "$hermes_bin" ] || { echo "ERROR: hermes not found. PATH=$PATH" >&2; exit 127; }
+  command -v gh >/dev/null 2>&1 || { echo "ERROR: gh not found. PATH=$PATH" >&2; exit 127; }
   [ -x "$pr_review_cmd" ] || { echo "ERROR: missing executable $pr_review_cmd" >&2; exit 127; }
   [ -x "$agent_cmd" ] || { echo "ERROR: missing executable $agent_cmd" >&2; exit 127; }
 
-  tmux new-session -d -s "$session" -n review -c "$HOME" "$agent_cmd $scope"
+  tmux new-session -d -s "$session" -n review -c "$HOME" "HERMES_BIN='$hermes_bin' '$agent_cmd' '$scope'"
   left_pane="$(tmux list-panes -t "$session:review" -F '#{pane_id}' | head -n1)"
   right_pane="$(tmux split-window -h -t "$session:review" -c "$HOME/src/profile" -P -F '#{pane_id}' "$pr_review_cmd")"
   tmux resize-pane -t "$left_pane" -x 55%
 
   # Restart the left pane with the right pane id injected so Hermes can drive gh-dash.
-  tmux respawn-pane -k -t "$left_pane" "$agent_cmd $scope '$right_pane'"
+  tmux respawn-pane -k -t "$left_pane" "HERMES_BIN='$hermes_bin' '$agent_cmd' '$scope' '$right_pane'"
   tmux select-pane -t "$left_pane"
 
   prompt_file="$(mktemp "${TMPDIR:-/tmp}/project-review-prompt.XXXXXX")"

--- a/bin/tmux/project-review-menu
+++ b/bin/tmux/project-review-menu
@@ -27,7 +27,8 @@ USAGE
   esac
 done
 
-profile_bin="$HOME/src/profile"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+profile_bin="$(cd -- "$script_dir/../.." && pwd)"
 pr_review_cmd="$profile_bin/bin/gh/pr-review"
 agent_cmd="$profile_bin/bin/tmux/project-review-agent"
 

--- a/bin/tmux/tmux.conf
+++ b/bin/tmux/tmux.conf
@@ -56,8 +56,8 @@ bind-key S-Left swap-window -t -1
 bind-key S-right swap-window -t +1
 
 # Context-aware project/PR review menu.
-# Prefix P opens a reusable popup menu; Prefix C-p opens the same menu fullscreen.
-bind-key P display-popup -E -w 80% -h 70% "$HOME/src/profile/bin/tmux/project-review-menu --mode popup --client '#{client_tty}'"
+# Prefix P opens a tmux-native menu; Prefix C-p opens the shell menu fullscreen.
+bind-key P run-shell "$HOME/src/profile/bin/tmux/project-review-menu --tmux-menu --client '#{client_tty}'"
 bind-key C-p new-window -n review-menu -c "$HOME/src/profile" "$HOME/src/profile/bin/tmux/project-review-menu --mode window --client '#{client_tty}'"
 
 set -g @plugin 'tmux-plugins/tpm'

--- a/bin/tmux/tmux.conf
+++ b/bin/tmux/tmux.conf
@@ -55,6 +55,11 @@ bind-key E split-window -h "vim ~/profile/.tmux.conf"
 bind-key S-Left swap-window -t -1
 bind-key S-right swap-window -t +1
 
+# Terminal-native GitHub PR review via gh-dash.
+# Prefix P opens a pane; Prefix C-p opens a full window.
+bind-key P split-window -h -c "#{pane_current_path}" "$HOME/src/profile/bin/gh/pr-review"
+bind-key C-p new-window -n pr-review -c "$HOME/src/profile" "$HOME/src/profile/bin/gh/pr-review"
+
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/vim-tmux'

--- a/bin/tmux/tmux.conf
+++ b/bin/tmux/tmux.conf
@@ -57,8 +57,8 @@ bind-key S-right swap-window -t +1
 
 # Context-aware project/PR review menu.
 # Prefix P opens a reusable popup menu; Prefix C-p opens the same menu fullscreen.
-bind-key P display-popup -E -w 80% -h 70% "$HOME/src/profile/bin/tmux/project-review-menu --mode popup"
-bind-key C-p new-window -n review-menu -c "$HOME/src/profile" "$HOME/src/profile/bin/tmux/project-review-menu --mode window"
+bind-key P display-popup -E -w 80% -h 70% "$HOME/src/profile/bin/tmux/project-review-menu --mode popup --client '#{client_tty}'"
+bind-key C-p new-window -n review-menu -c "$HOME/src/profile" "$HOME/src/profile/bin/tmux/project-review-menu --mode window --client '#{client_tty}'"
 
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'

--- a/bin/tmux/tmux.conf
+++ b/bin/tmux/tmux.conf
@@ -55,10 +55,10 @@ bind-key E split-window -h "vim ~/profile/.tmux.conf"
 bind-key S-Left swap-window -t -1
 bind-key S-right swap-window -t +1
 
-# Terminal-native GitHub PR review via gh-dash.
-# Prefix P opens a pane; Prefix C-p opens a full window.
-bind-key P split-window -h -c "#{pane_current_path}" "$HOME/src/profile/bin/gh/pr-review"
-bind-key C-p new-window -n pr-review -c "$HOME/src/profile" "$HOME/src/profile/bin/gh/pr-review"
+# Context-aware project/PR review menu.
+# Prefix P opens a reusable popup menu; Prefix C-p opens the same menu fullscreen.
+bind-key P display-popup -E -w 80% -h 70% "$HOME/src/profile/bin/tmux/project-review-menu --mode popup"
+bind-key C-p new-window -n review-menu -c "$HOME/src/profile" "$HOME/src/profile/bin/tmux/project-review-menu --mode window"
 
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'


### PR DESCRIPTION
## Summary
- add an off-the-shelf gh-dash configuration for reviewing Karan-authored PRs in the terminal
- add profile wrappers to ensure/launch the gh-dash extension
- add tmux shortcuts: prefix P for a pane, prefix C-p for a full pr-review window

## Why
Keep PR review inside the terminal/tmux workflow without building a bespoke PR dashboard.

## Usage
- terminal: ~/src/profile/bin/gh/pr-review
- tmux pane: prefix P
- tmux window: prefix C-p

## Verification
- bash -n bin/gh/ensure-gh-dash bin/gh/pr-review
- parsed bin/gh/gh-dash/config.yml with PyYAML and asserted sections/repoPaths/pager
- git diff --check
- validated tmux config in isolated tmux server and confirmed bindings
- verified gh search returns open Karan-authored PRs under karanhiremath
- verified gh dash extension installed
- smoke-started gh dash with the checked-in config in a pseudo-terminal; it stayed open until timeout (no immediate config error)
