### PR TITLE
Add Hermes voice Ansible role

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -42,3 +42,49 @@ PROFILE_ALLOW_HOST_MUTATION=1 TAGS=ssh_authorized_keys just ansible-apply
 ```
 
 The Ansible task uses `no_log: true` for fetched key material.
+
+## Hermes CoS/CoSW voice secrets from 1Password
+
+Personal hosts enable `hermes_voice` by default via `group_vars/personal.yml`.
+The role installs a local helper that resolves the shared Cartesia key from
+1Password at launch time; it does **not** write the Cartesia API key to disk.
+Profile-local `config.yaml` still controls the voice/model.
+
+Shared reference:
+
+```text
+op://agent-stack/karan.hiremath-hermes/credential
+```
+
+Run/apply only this role:
+
+```bash
+TAGS=hermes_voice just ansible-plan
+PROFILE_ALLOW_HOST_MUTATION=1 TAGS=hermes_voice just ansible-apply
+```
+
+The role installs:
+
+```text
+~/.local/bin/hermes-cartesia-env
+```
+
+`bin/hermes/agents` automatically calls that helper before launching a profile
+whose materialized config uses `provider: cartesia`.
+
+### Personal service-account bootstrap
+
+For personal use, `group_vars/personal.yml` enables creation of a scoped
+1Password service account token. The token has read access to `agent-stack` and
+is stored in macOS Keychain; it is not committed and is not the Cartesia API key.
+
+Keychain item:
+
+```text
+service: Hermes OP_SERVICE_ACCOUNT_TOKEN my.1password.com agent-stack
+account: <local user>
+```
+
+If the machine is not signed in to 1Password CLI, service-account creation fails
+closed with an authorization error. Sign in/unlock 1Password, then rerun the
+`hermes_voice` apply command above.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -48,3 +48,26 @@ profile_ssh_authorized_keys_op_ref: ""
 profile_ssh_authorized_keys: []
 profile_ssh_authorized_keys_user: "{{ ansible_facts.user_id }}"
 profile_ssh_authorized_keys_exclusive: false
+
+# Hermes CoS/CoSW voice setup.
+# This installs a helper that resolves the shared Cartesia API key from
+# 1Password at runtime; profile-specific config still controls voice/model.
+profile_hermes_voice_enabled: false
+profile_hermes_voice_install_op_cli: true
+profile_hermes_voice_op_account: my.1password.com
+profile_hermes_voice_cartesia_op_ref: "op://agent-stack/karan.hiremath-hermes/credential"
+profile_hermes_voice_helper_path: "{{ profile_home }}/.local/bin/hermes-cartesia-env"
+profile_hermes_voice_verify_op_ref: false
+
+# Optional bootstrap: create a 1Password service account token and store it in
+# the local macOS Keychain. Off by default because the token is returned once and
+# should be created deliberately.
+profile_hermes_voice_create_service_account_token: false
+profile_hermes_voice_service_account_name: "hermes-voice-{{ ansible_facts.hostname | default(inventory_hostname) }}"
+profile_hermes_voice_service_account_vault: agent-stack
+profile_hermes_voice_service_account_expires_in: 30d
+profile_hermes_voice_keychain_account: "{{ ansible_facts.user_id }}"
+profile_hermes_voice_op_token_keychain_service: "Hermes OP_SERVICE_ACCOUNT_TOKEN my.1password.com agent-stack"
+profile_hermes_voice_op_token_keychain_comment: >-
+  1Password service account token for Hermes voice agents; vault=agent-stack;
+  reference={{ profile_hermes_voice_cartesia_op_ref }}

--- a/ansible/group_vars/personal.yml
+++ b/ansible/group_vars/personal.yml
@@ -1,2 +1,6 @@
 ---
 profile_env: personal
+
+# Personal machines should be able to run voice-enabled CoS/CoSW agents.
+profile_hermes_voice_enabled: true
+profile_hermes_voice_create_service_account_token: true

--- a/ansible/roles/hermes_voice/tasks/main.yml
+++ b/ansible/roles/hermes_voice/tasks/main.yml
@@ -1,0 +1,123 @@
+---
+- name: Validate Hermes voice 1Password configuration
+  ansible.builtin.assert:
+    that:
+      - profile_hermes_voice_cartesia_op_ref | length > 0
+      - profile_hermes_voice_op_account | length > 0
+    fail_msg: >-
+      profile_hermes_voice_enabled=true requires profile_hermes_voice_op_account
+      and profile_hermes_voice_cartesia_op_ref.
+  when: profile_hermes_voice_enabled | bool
+
+- name: Install 1Password CLI on macOS when requested
+  community.general.homebrew_cask:
+    name: 1password-cli
+    state: present
+  when:
+    - profile_hermes_voice_enabled | bool
+    - profile_hermes_voice_install_op_cli | bool
+    - ansible_facts.system == 'Darwin'
+  tags: [op, onepassword]
+
+- name: Check 1Password CLI is available
+  ansible.builtin.command:
+    argv:
+      - "{{ profile_op_cli }}"
+      - --version
+  changed_when: false
+  register: profile_hermes_voice_op_version
+  when: profile_hermes_voice_enabled | bool
+  tags: [op, onepassword]
+
+- name: Ensure local bin directory exists
+  ansible.builtin.file:
+    path: "{{ profile_hermes_voice_helper_path | dirname }}"
+    state: directory
+    mode: '0755'
+  when: profile_hermes_voice_enabled | bool
+
+- name: Install Hermes Cartesia 1Password environment helper
+  ansible.builtin.template:
+    src: hermes-cartesia-env.j2
+    dest: "{{ profile_hermes_voice_helper_path }}"
+    mode: '0700'
+  when: profile_hermes_voice_enabled | bool
+
+- name: Check whether local OP service account token already exists in Keychain
+  ansible.builtin.command:
+    argv:
+      - security
+      - find-generic-password
+      - -a
+      - "{{ profile_hermes_voice_keychain_account }}"
+      - -s
+      - "{{ profile_hermes_voice_op_token_keychain_service }}"
+  changed_when: false
+  failed_when: false
+  register: profile_hermes_voice_existing_op_token
+  no_log: true
+  when:
+    - profile_hermes_voice_enabled | bool
+    - ansible_facts.system == 'Darwin'
+    - profile_hermes_voice_create_service_account_token | bool
+
+- name: Create scoped 1Password service account token for Hermes voice access
+  ansible.builtin.command:
+    argv:
+      - "{{ profile_op_cli }}"
+      - service-account
+      - create
+      - "{{ profile_hermes_voice_service_account_name }}"
+      - --vault
+      - "{{ profile_hermes_voice_service_account_vault }}:read_items"
+      - --expires-in
+      - "{{ profile_hermes_voice_service_account_expires_in }}"
+      - --raw
+  environment:
+    OP_ACCOUNT: "{{ profile_hermes_voice_op_account }}"
+  changed_when: true
+  check_mode: false
+  register: profile_hermes_voice_new_op_token
+  no_log: true
+  when:
+    - profile_hermes_voice_enabled | bool
+    - ansible_facts.system == 'Darwin'
+    - profile_hermes_voice_create_service_account_token | bool
+    - profile_hermes_voice_existing_op_token.rc | default(1) != 0
+
+- name: Store OP service account token in macOS Keychain
+  ansible.builtin.command:
+    argv:
+      - security
+      - add-generic-password
+      - -U
+      - -a
+      - "{{ profile_hermes_voice_keychain_account }}"
+      - -s
+      - "{{ profile_hermes_voice_op_token_keychain_service }}"
+      - -D
+      - application password
+      - -j
+      - "{{ profile_hermes_voice_op_token_keychain_comment }}"
+      - -w
+      - "{{ profile_hermes_voice_new_op_token.stdout }}"
+  changed_when: true
+  no_log: true
+  when:
+    - profile_hermes_voice_enabled | bool
+    - ansible_facts.system == 'Darwin'
+    - profile_hermes_voice_create_service_account_token | bool
+    - profile_hermes_voice_new_op_token is defined
+    - profile_hermes_voice_new_op_token.stdout | default('') | length > 0
+
+- name: Verify Cartesia 1Password reference is resolvable when requested
+  ansible.builtin.command:
+    argv:
+      - "{{ profile_hermes_voice_helper_path }}"
+      - --check
+  changed_when: false
+  register: profile_hermes_voice_check
+  no_log: true
+  when:
+    - profile_hermes_voice_enabled | bool
+    - profile_hermes_voice_verify_op_ref | bool

--- a/ansible/roles/hermes_voice/templates/hermes-cartesia-env.j2
+++ b/ansible/roles/hermes_voice/templates/hermes-cartesia-env.j2
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Managed by ~/src/profile Ansible role hermes_voice.
+# Resolve the shared Cartesia API key from 1Password without writing it to disk.
+set -euo pipefail
+
+ACCOUNT="${OP_ACCOUNT:-{{ profile_hermes_voice_op_account }}}"
+REF="${CARTESIA_1PASSWORD_REF:-{{ profile_hermes_voice_cartesia_op_ref }}}"
+KEYCHAIN_SERVICE="${OP_SERVICE_ACCOUNT_TOKEN_KEYCHAIN_SERVICE:-{{ profile_hermes_voice_op_token_keychain_service }}}"
+KEYCHAIN_ACCOUNT="${OP_SERVICE_ACCOUNT_TOKEN_KEYCHAIN_ACCOUNT:-{{ profile_hermes_voice_keychain_account }}}"
+MODE="${1:-export}"
+
+if ! command -v {{ profile_op_cli }} >/dev/null 2>&1; then
+  echo "1Password CLI '{{ profile_op_cli }}' is not installed or not on PATH" >&2
+  exit 127
+fi
+
+# Prefer an explicitly provided OP_SERVICE_ACCOUNT_TOKEN. Otherwise, on macOS,
+# read the local machine bootstrap token from Keychain. This token grants read
+# access to the shared 1Password item; it is not the Cartesia API key itself.
+if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]] && command -v security >/dev/null 2>&1; then
+  token="$(security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$KEYCHAIN_SERVICE" -w 2>/dev/null || true)"
+  if [[ -n "$token" ]]; then
+    export OP_SERVICE_ACCOUNT_TOKEN="$token"
+  fi
+fi
+
+value="$({{ profile_op_cli }} read --account "$ACCOUNT" --no-newline "$REF" 2>/dev/null || true)"
+if [[ -z "$value" || "$value" == "REPLACE_WITH_CARTESIA_API_KEY" ]]; then
+  cat >&2 <<EOF
+Cartesia key not available from 1Password.
+Expected shared secret reference:
+  $REF
+Account:
+  $ACCOUNT
+
+For unattended hosts, provision OP_SERVICE_ACCOUNT_TOKEN or a macOS Keychain item:
+  service: $KEYCHAIN_SERVICE
+  account: $KEYCHAIN_ACCOUNT
+EOF
+  exit 1
+fi
+
+if [[ "$MODE" == "--check" ]]; then
+  echo "ok: Cartesia 1Password reference resolved (secret redacted)"
+  exit 0
+fi
+
+printf 'export CARTESIA_API_KEY=%q\n' "$value"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -32,6 +32,8 @@
       tags: [dotfiles]
     - role: ssh_authorized_keys
       tags: [ssh_authorized_keys, ssh]
+    - role: hermes_voice
+      tags: [hermes_voice, voice, onepassword, op]
     - role: cli_tools
       tags: [cli_tools]
     - role: mac_apps

--- a/bin/hermes/agents
+++ b/bin/hermes/agents
@@ -126,6 +126,17 @@ case "$cmd" in
     fi
     echo "profile=$profile surface=$surface home=$home runtime_home=$runtime_home"
 
+    # Voice-enabled Cartesia profiles should get CARTESIA_API_KEY from the
+    # host-level 1Password helper installed by the Ansible hermes_voice role.
+    # The helper prints shell export syntax and never logs the secret. If the
+    # helper is absent, existing env/.env behavior remains unchanged.
+    if [ -z "${CARTESIA_API_KEY:-}" ] && [ -f "$runtime_home/config.yaml" ] && grep -q 'provider: cartesia' "$runtime_home/config.yaml"; then
+      cartesia_helper="${HERMES_CARTESIA_ENV_HELPER:-$HOME/.local/bin/hermes-cartesia-env}"
+      if [ -x "$cartesia_helper" ]; then
+        eval "$("$cartesia_helper")" || die "failed to resolve Cartesia API key via $cartesia_helper"
+      fi
+    fi
+
     if [ "$do_check" -eq 1 ]; then
       HERMES_HOME="$runtime_home" "$PY" "$PLUGIN_DIR/validate.py" --tts --stt || die "endpoint health check failed; not launching"
     fi


### PR DESCRIPTION
## Summary
- add `hermes_voice` Ansible role for runtime 1Password resolution of the Cartesia API key
- wire role into personal Ansible vars/site tags
- teach `bin/hermes/agents` to invoke the helper for Cartesia-backed profiles when `CARTESIA_API_KEY` is unset

## Safety
- no API key/token values committed
- helper emits shell export syntax only at launch time
- token creation/apply flow is for review; do not run/merge without explicit approval

## Validation
- `bash -n bin/hermes/agents ansible/roles/hermes_voice/templates/hermes-cartesia-env.j2`
- `git diff --cached --check`
